### PR TITLE
Fvcore to iopath

### DIFF
--- a/datasets/format_mridata_org.py
+++ b/datasets/format_mridata_org.py
@@ -33,13 +33,13 @@ import mridata
 import numpy as np
 import sigpy as sp
 import torch
-from fvcore.common.file_io import PathManager
 from sigpy.mri import app
 from tqdm import tqdm
 from utils import fftc
 
 from meddlr.forward import SenseModel
 from meddlr.ops import complex as cplx
+from meddlr.utils import env
 from meddlr.utils.logger import setup_logger
 
 _FILE_DIR = os.path.dirname(__file__)
@@ -49,6 +49,8 @@ BIN_BART = "bart"
 OUTPUT_DIR = "data://mridata_knee_2019"
 _LOGGER_NAME = "{}.{}".format(_FILE_NAME, __name__)
 logger = logging.getLogger(_LOGGER_NAME)
+
+_PATH_MANAGER = env.get_path_manager()
 
 
 def download_mridata_org_dataset(file_name, dir_output, overwrite: bool = False):
@@ -321,7 +323,7 @@ if __name__ == "__main__":
     if args.random_seed >= 0:
         np.random.seed(args.random_seed)
 
-    root_dir = PathManager.get_local_path(args.output)
+    root_dir = _PATH_MANAGER.get_local_path(args.output)
     setup_logger(root_dir, name=_FILE_NAME)
 
     logger.info("Args:\n{}".format(args))
@@ -367,6 +369,6 @@ if __name__ == "__main__":
 
         # Save annotation files.
         ann_file = os.path.join(root_dir, "annotations", "{}.json".format(split))
-        ann_dir = os.path.dirname(PathManager.get_local_path(ann_file))
+        ann_dir = os.path.dirname(_PATH_MANAGER.get_local_path(ann_file))
         os.makedirs(ann_dir, exist_ok=True)
         write_ann_file(ann_file, dir_h5_data, split)

--- a/meddlr/data/datasets/register_mrco.py
+++ b/meddlr/data/datasets/register_mrco.py
@@ -7,11 +7,12 @@ import time
 
 import h5py
 import pandas as pd
-from fvcore.common.file_io import PathManager
 
 from meddlr.data import DatasetCatalog, MetadataCatalog
+from meddlr.utils import env
 
 logger = logging.getLogger(__name__)
+_PATH_MANAGER = env.get_path_manager()
 
 __all__ = ["load_mrco_json", "register_mrco_scans"]
 
@@ -38,7 +39,7 @@ def load_mrco_json(json_file: str, image_root: str, dataset_name: str):
         1. This function does not read the image files.
            The results do not have the "kspace", "target", or "maps" fields.
     """
-    json_file = PathManager.get_local_path(json_file)
+    json_file = _PATH_MANAGER.get_local_path(json_file)
     start_time = time.perf_counter()
     with open(json_file, "r") as f:
         data = json.load(f)
@@ -51,9 +52,9 @@ def load_mrco_json(json_file: str, image_root: str, dataset_name: str):
     for d in data["images"]:
         dd = dict(d)
         if image_root is not None:
-            file_name = PathManager.get_local_path(os.path.join(image_root, d["file_name"]))
+            file_name = _PATH_MANAGER.get_local_path(os.path.join(image_root, d["file_name"]))
         else:
-            file_name = PathManager.get_local_path(d["file_path"])
+            file_name = _PATH_MANAGER.get_local_path(d["file_path"])
         dd["file_name"] = file_name
 
         # TODO: Clean this up
@@ -109,7 +110,7 @@ def _load_metadata(metadata_file, dataset_dicts):
         dataset_dicts: The dataset dictionaries with "_metadata" key.
             This key maps to the dictionary of metadata.
     """
-    metadata = pd.read_csv(PathManager.get_local_path(metadata_file))
+    metadata = pd.read_csv(_PATH_MANAGER.get_local_path(metadata_file))
     metadata = metadata.loc[:, ~metadata.columns.str.contains("^Unnamed")]
 
     for dd in dataset_dicts:

--- a/meddlr/engine/defaults.py
+++ b/meddlr/engine/defaults.py
@@ -16,7 +16,6 @@ import warnings
 from typing import Mapping, Sequence
 
 import torch
-from fvcore.common.file_io import PathManager
 
 from meddlr.config.config import CfgNode
 from meddlr.utils import env
@@ -25,6 +24,8 @@ from meddlr.utils.env import get_available_gpus, seed_all_rng
 from meddlr.utils.logger import setup_logger
 
 __all__ = ["default_argument_parser", "default_setup"]
+
+_PATH_MANAGER = env.get_path_manager()
 
 
 def default_argument_parser() -> argparse.ArgumentParser:
@@ -90,14 +91,14 @@ def default_setup(cfg, args, save_cfg: bool = True):
 
     # Update config parameters before saving.
     cfg.defrost()
-    cfg.OUTPUT_DIR = PathManager.get_local_path(cfg.OUTPUT_DIR)
+    cfg.OUTPUT_DIR = _PATH_MANAGER.get_local_path(cfg.OUTPUT_DIR)
     if is_repro_mode:
         init_reproducible_mode(cfg, eval_only)
     cfg.freeze()
 
     output_dir = cfg.OUTPUT_DIR
     if output_dir:
-        PathManager.mkdirs(output_dir)
+        _PATH_MANAGER.mkdirs(output_dir)
 
     setup_logger(output_dir, name="fvcore")
     logger = setup_logger(output_dir)
@@ -115,7 +116,7 @@ def default_setup(cfg, args, save_cfg: bool = True):
     if hasattr(args, "config_file") and args.config_file != "":
         logger.info(
             "Contents of args.config_file={}:\n{}".format(
-                args.config_file, PathManager.open(args.config_file, "r").read()
+                args.config_file, _PATH_MANAGER.open(args.config_file, "r").read()
             )
         )
 
@@ -139,7 +140,7 @@ def default_setup(cfg, args, save_cfg: bool = True):
         # Note: some of our scripts may expect the existence of
         # config.yaml in output directory
         path = os.path.join(output_dir, "config.yaml")
-        with PathManager.open(path, "w") as f:
+        with _PATH_MANAGER.open(path, "w") as f:
             f.write(cfg.dump())
         logger.info("Full config saved to {}".format(os.path.abspath(path)))
 

--- a/meddlr/engine/hooks.py
+++ b/meddlr/engine/hooks.py
@@ -13,14 +13,13 @@ from collections import Counter
 
 import torch
 from fvcore.common.checkpoint import PeriodicCheckpointer as _PeriodicCheckpointer
-from fvcore.common.file_io import PathManager
 from fvcore.common.timer import Timer
 
+from meddlr.engine.train_loop import HookBase
 from meddlr.evaluation.testing import flatten_results_dict
 from meddlr.solver import GradAccumOptimizer
+from meddlr.utils import env
 from meddlr.utils.events import EventWriter
-
-from .train_loop import HookBase
 
 try:
     from guppy import hpy
@@ -39,6 +38,7 @@ __all__ = [
     "FlushOptimizer",
 ]
 
+_PATH_MANAGER = env.get_path_manager()
 
 """
 Implement some common hooks.
@@ -308,7 +308,7 @@ class AutogradProfiler(HookBase):
                 self._profiler.export_chrome_trace(tmp_file)
                 with open(tmp_file) as f:
                     content = f.read()
-            with PathManager.open(out_file, "w") as f:
+            with _PATH_MANAGER.open(out_file, "w") as f:
                 f.write(content)
 
 

--- a/meddlr/utils/cluster.py
+++ b/meddlr/utils/cluster.py
@@ -9,13 +9,14 @@ from abc import ABC, abstractmethod
 from typing import Any, Dict, List, Sequence, Union
 
 import yaml
-from fvcore.common.file_io import PathHandler, PathManager
+from iopath.common.file_io import PathHandler
 
-from .env import settings_dir
+from meddlr.utils import env
 
 # Path to the repository directory.
 # TODO: make this cleaner
 _REPO_DIR = os.path.join(os.path.dirname(__file__), "../..")
+_PATH_MANAGER = env.get_path_manager()
 
 __all__ = ["Cluster", "set_cluster"]
 
@@ -107,7 +108,7 @@ class Cluster:
     def data_dir(self):
         path = self._data_dir
         path = os.environ.get("MEDDLR_DATASETS_DIR", path if path else "./datasets")
-        return PathManager.get_local_path(path)
+        return _PATH_MANAGER.get_local_path(path)
 
     @property
     def datasets_dir(self):
@@ -118,13 +119,13 @@ class Cluster:
     def results_dir(self):
         path = self._results_dir
         path = os.environ.get("MEDDLR_RESULTS_DIR", path if path else "./results")
-        return PathManager.get_local_path(path)
+        return _PATH_MANAGER.get_local_path(path)
 
     @property
     def cache_dir(self):
         path = self._cache_dir
         path = os.environ.get("MEDDLR_CACHE_DIR", path if path else "~/cache/meddlr")
-        return PathManager.get_local_path(path)
+        return _PATH_MANAGER.get_local_path(path)
 
     def set(self, **kwargs):
         """Set cluster configuration properties.
@@ -244,7 +245,7 @@ class Cluster:
 
     @staticmethod
     def config_file():
-        return os.path.join(settings_dir(), "clusters.yaml")
+        return os.path.join(env.settings_dir(), "clusters.yaml")
 
     @staticmethod
     def working_cluster() -> "Cluster":
@@ -304,7 +305,7 @@ class GeneralPathHandler(PathHandler, ABC):
         return os.path.join(self._root_dir(), name)
 
     def _open(self, path, mode="r", **kwargs):
-        return PathManager.open(self._get_local_path(path), mode, **kwargs)
+        return _PATH_MANAGER.open(self._get_local_path(path), mode, **kwargs)
 
     def _mkdirs(self, path: str, **kwargs):
         os.makedirs(self._get_local_path(path), exist_ok=True)
@@ -337,6 +338,6 @@ class AnnotationsHandler(GeneralPathHandler):
         return os.path.abspath(os.path.join(_REPO_DIR, "annotations"))
 
 
-PathManager.register_handler(DataHandler())
-PathManager.register_handler(ResultsHandler())
-PathManager.register_handler(AnnotationsHandler())
+_PATH_MANAGER.register_handler(DataHandler())
+_PATH_MANAGER.register_handler(ResultsHandler())
+_PATH_MANAGER.register_handler(AnnotationsHandler())

--- a/meddlr/utils/env.py
+++ b/meddlr/utils/env.py
@@ -18,6 +18,7 @@ __all__ = []
 
 _PT_VERSION = torch.__version__
 _SETTINGS_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), "../.settings"))
+_GITHUB_URL = "https://github.com/ad12/meddlr"
 _SUPPORTED_PACKAGES = {}
 
 
@@ -276,3 +277,7 @@ def settings_dir():
 
 def get_path_manager(key="meddlr") -> PathManager:
     return PathManagerFactory.get(key)
+
+
+def get_github_url() -> str:
+    return _GITHUB_URL

--- a/meddlr/utils/env.py
+++ b/meddlr/utils/env.py
@@ -12,6 +12,7 @@ from typing import List
 
 import numpy as np
 import torch
+from iopath.common.file_io import PathManager, PathManagerFactory
 
 __all__ = []
 
@@ -271,3 +272,7 @@ def is_main_process():
 
 def settings_dir():
     return os.environ.get("MEDDLR_SETTINGS", _SETTINGS_DIR)
+
+
+def get_path_manager(key="meddlr") -> PathManager:
+    return PathManagerFactory.get(key)

--- a/meddlr/utils/events.py
+++ b/meddlr/utils/events.py
@@ -12,10 +12,9 @@ from collections import defaultdict
 from contextlib import contextmanager
 
 import torch
-from fvcore.common.file_io import PathManager
 from fvcore.common.history_buffer import HistoryBuffer
 
-from meddlr.utils.env import supports_wandb
+from meddlr.utils.env import get_path_manager, supports_wandb
 
 try:
     import wandb
@@ -23,6 +22,7 @@ except ImportError:
     pass
 
 _CURRENT_STORAGE_STACK = []
+_PATH_MANAGER = get_path_manager()
 
 
 def get_event_storage():
@@ -105,7 +105,7 @@ class JSONWriter(EventWriter):
             window_size (int): the window size of median smoothing for the
                 scalars whose `smoothing_hint` are True.
         """
-        self._file_handle = PathManager.open(json_file, "a")
+        self._file_handle = _PATH_MANAGER.open(json_file, "a")
         self._window_size = window_size
 
     def write(self):

--- a/meddlr/utils/general.py
+++ b/meddlr/utils/general.py
@@ -2,7 +2,10 @@ import os
 from typing import List, Mapping
 
 import torch
-from fvcore.common.file_io import PathManager
+
+from meddlr.utils import env
+
+_PATH_MANAGER = env.get_path_manager()
 
 
 def move_to_device(obj, device, non_blocking=False, base_types=None):
@@ -74,7 +77,7 @@ def find_experiment_dirs(dirpath, completed=True) -> List[str]:
             exp_dirs.extend(_find_exp_dirs(dp))
         return exp_dirs
 
-    dirpath = PathManager.get_local_path(dirpath)
+    dirpath = _PATH_MANAGER.get_local_path(dirpath)
     exp_dirs = _find_exp_dirs(dirpath)
     if completed:
         exp_dirs = [x for x in exp_dirs if os.path.isfile(os.path.join(x, "model_final.pth"))]

--- a/meddlr/utils/logger.py
+++ b/meddlr/utils/logger.py
@@ -10,9 +10,12 @@ import sys
 import time
 from collections import Counter
 
-from fvcore.common.file_io import PathManager
 from tabulate import tabulate
 from termcolor import colored
+
+from meddlr.utils import env
+
+_PATH_MANAGER = env.get_path_manager()
 
 
 class _ColorfulFormatter(logging.Formatter):
@@ -92,7 +95,7 @@ def setup_logger(output=None, distributed_rank=0, *, color=True, name="meddlr", 
             filename = os.path.join(output, "log.txt")
         if distributed_rank > 0:
             filename = filename + ".rank{}".format(distributed_rank)
-        PathManager.mkdirs(os.path.dirname(filename))
+        _PATH_MANAGER.mkdirs(os.path.dirname(filename))
 
         fh = logging.StreamHandler(_cached_log_stream(filename))
         fh.setLevel(logging.DEBUG)
@@ -106,7 +109,7 @@ def setup_logger(output=None, distributed_rank=0, *, color=True, name="meddlr", 
 # with the same file name can safely write to the same file.
 @functools.lru_cache(maxsize=None)
 def _cached_log_stream(filename):
-    return PathManager.open(filename, "a")
+    return _PATH_MANAGER.open(filename, "a")
 
 
 """

--- a/setup.py
+++ b/setup.py
@@ -99,6 +99,7 @@ setup(
         "tqdm",
         "omegaconf",
         "torchmetrics>=0.5.1",
+        "iopath",
     ],
     extras_require={
         "dev": [

--- a/tests/utils/test_cluster.py
+++ b/tests/utils/test_cluster.py
@@ -2,7 +2,7 @@ import os
 import socket
 import unittest
 
-from meddlr.utils.cluster import Cluster
+from meddlr.utils.cluster import Cluster, download_repository
 
 from ..util import temp_env
 
@@ -73,3 +73,9 @@ class TestCluster(unittest.TestCase):
         with self.assertRaises(KeyError):
             # Once deleted the cluster should not be found.
             cluster2 = cluster.from_config(name)
+
+
+def test_download_github(tmpdir):
+    download_dir = tmpdir.mkdir("download")
+    download_repository(version="main", path=download_dir)
+    assert os.path.isdir(download_dir.join("annotations").strpath)


### PR DESCRIPTION
Convert fvcore PathManager (deprecated) -> iopath PathManager

- [x] Replace all fvcore path manager with iopath path managers
- [x] Add support for downloading/caching annotations directory from github
- [x] run native testing for training/evaluation experiments