### PR TITLE
add support for gdrive public file download

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # meddlr
 ![GitHub Workflow Status](https://img.shields.io/github/workflow/status/ad12/meddlr/CI)
 ![GitHub](https://img.shields.io/github/license/ad12/meddlr)
+[![Documentation Status](https://readthedocs.org/projects/meddlr/badge/?version=latest)](https://meddlr.readthedocs.io/en/latest/?badge=latest)
 [![pre-commit](https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit&logoColor=white)](https://github.com/pre-commit/pre-commit)
 <!-- [![codecov](https://codecov.io/gh/ad12/meddlr/branch/main/graph/badge.svg?token=U6H83UCGFU)](https://codecov.io/gh/ad12/meddlr) -->
 

--- a/configs/tests/basic-with-deps.yaml
+++ b/configs/tests/basic-with-deps.yaml
@@ -1,0 +1,30 @@
+# Basic testing config
+# Use this for any testing you may want to do in the future.
+# The model will be trained for 60 iterations (not epochs)
+# on the mridata.org 2019 knee dataset.
+# DEPENDENCY: numpy>=1.0.0
+# DEPENDENCY: torch
+# DEPENDENCY: meddlr; iopath
+MODEL:
+  UNROLLED:
+    NUM_UNROLLED_STEPS: 8
+    NUM_RESBLOCKS: 2
+    NUM_FEATURES: 128
+    DROPOUT: 0.
+DATASETS:
+  TRAIN: ("mridata_knee_2019_train",)
+  VAL: ("mridata_knee_2019_val",)
+  TEST: ("mridata_knee_2019_test",)
+DATALOADER:
+  NUM_WORKERS: 0  # for debugging purposes
+SOLVER:
+  TRAIN_BATCH_SIZE: 1
+  TEST_BATCH_SIZE: 2
+  CHECKPOINT_PERIOD: 20
+  MAX_ITER: 80
+TEST:
+  EVAL_PERIOD: 40
+VIS_PERIOD: 20
+TIME_SCALE: "iter"
+OUTPUT_DIR: "results://tests/basic"
+VERSION: 1

--- a/meddlr/utils/env.py
+++ b/meddlr/utils/env.py
@@ -4,15 +4,18 @@ import logging
 import multiprocessing as mp
 import os
 import random
+import re
 import subprocess
 import sys
 import warnings
 from datetime import datetime
+from importlib import util
 from typing import List
 
 import numpy as np
 import torch
 from iopath.common.file_io import PathManager, PathManagerFactory
+from packaging import version
 
 __all__ = []
 
@@ -184,6 +187,81 @@ def package_available(name: str):
     if name not in _SUPPORTED_PACKAGES:
         _SUPPORTED_PACKAGES[name] = importlib.util.find_spec(name) is not None
     return _SUPPORTED_PACKAGES[name]
+
+
+def get_package_version(package_or_name) -> str:
+    """Returns package version.
+
+    Args:
+        package_or_name (``module`` or ``str``): Module or name of module.
+            This package must have the version accessible through ``<module>.__version__``.
+
+    Returns:
+        str: The package version.
+
+    Examples:
+        >>> get_version("numpy")
+        "1.20.0"
+    """
+    if isinstance(package_or_name, str):
+        if not package_available(package_or_name):
+            raise ValueError(f"Package {package_or_name} not available")
+        spec = util.find_spec(package_or_name)
+        package_or_name = util.module_from_spec(spec)
+        spec.loader.exec_module(package_or_name)
+    version = package_or_name.__version__
+    return version
+
+
+def is_package_installed(pkg_str) -> bool:
+    """Verify that a package dependency is installed and in the expected version range.
+
+    This is useful for optional third-party dependencies where implementation
+    changes are not backwards-compatible.
+
+    Args:
+        pkg_str (str): The pip formatted dependency string.
+            E.g. "numpy", "numpy>=1.0.0", "numpy>=1.0.0,<=1.10.0", "numpy==1.10.0"
+
+    Returns:
+        bool: Whether dependency is satisfied.
+
+    Note:
+        This cannot resolve packages where the pip name does not match the python
+        package name. ``'-'`` characters are automatically changed to ``'_'``.
+    """
+    ops = {
+        "==": lambda x, y: x == y,
+        "<=": lambda x, y: x <= y,
+        ">=": lambda x, y: x >= y,
+        "<": lambda x, y: x < y,
+        ">": lambda x, y: x > y,
+    }
+    comparison_patterns = "(==|<=|>=|>|<)"
+
+    pkg_str = pkg_str.strip()
+    pkg_str = pkg_str.replace("-", "_")
+    dependency = list(re.finditer(comparison_patterns, pkg_str))
+
+    if len(dependency) == 0:
+        return package_available(pkg_str)
+
+    pkg_name = pkg_str[: dependency[0].start()]
+    if not package_available(pkg_name):
+        return False
+
+    pkg_version = version.Version(get_package_version(pkg_name))
+    version_limits = pkg_str[dependency[0].start() :].split(",")
+
+    for vlimit in version_limits:
+        comp_loc = list(re.finditer(comparison_patterns, vlimit))
+        if len(comp_loc) != 1:
+            raise ValueError(f"Invalid version string: {pkg_str}")
+        comp_op = vlimit[comp_loc[0].start() : comp_loc[0].end()]
+        comp_version = version.Version(vlimit[comp_loc[0].end() :])
+        if not ops[comp_op](pkg_version, comp_version):
+            return False
+    return True
 
 
 def is_debug() -> bool:

--- a/setup.py
+++ b/setup.py
@@ -100,6 +100,7 @@ setup(
         "omegaconf",
         "torchmetrics>=0.5.1",
         "iopath",
+        "packaging",
     ],
     extras_require={
         "dev": [

--- a/setup.py
+++ b/setup.py
@@ -103,6 +103,7 @@ setup(
     ],
     extras_require={
         "dev": [
+            # Formatting
             "coverage",
             "flake8",
             "isort",
@@ -110,15 +111,19 @@ setup(
             "flake8-bugbear",
             "flake8-comprehensions",
             "pre-commit>=2.9.3",
+            # Testing
             "medpy",
             "pooch",
+            "gdown",
+            # Documentation
             "sphinx",
             "sphinxcontrib-bibtex",
             "sphinx-rtd-theme",
             "m2r2",
         ],
         "benchmarking": ["medpy"],
-        "docs": ["sphinx", "sphinxcontrib.bibtex", "m2r2"],
+        "deployment": ["gdown"],
+        "docs": ["sphinx", "sphinxcontrib.bibtex", "sphinx-rtd-theme", "m2r2"],
     },
     classifiers=[
         # Trove classifiers

--- a/tests/config/test_util.py
+++ b/tests/config/test_util.py
@@ -1,0 +1,8 @@
+from meddlr.config.util import check_dependencies
+
+from .. import util
+
+
+def test_check_dependencies():
+    cfg_file = util.get_cfg_path("tests/basic-with-deps.yaml")
+    assert check_dependencies(cfg_file)

--- a/tests/util.py
+++ b/tests/util.py
@@ -17,3 +17,12 @@ def temp_env(func):
         return out
 
     return wrapper
+
+
+def get_cfg_path(cfg_filename):
+    """Return path to config file."""
+    cfg_filename = cfg_filename.split("/")
+    cfg_filename = os.path.join(os.path.dirname(__file__), "..", "configs", *cfg_filename)
+    if not os.path.exists(cfg_filename):
+        raise FileNotFoundError(f"Config file {cfg_filename} not found.")
+    return cfg_filename

--- a/tests/utils/test_env.py
+++ b/tests/utils/test_env.py
@@ -80,5 +80,17 @@ class TestEnvVariables(unittest.TestCase):
         self._reset_var(env_var, orig_val)
 
 
+def test_is_package_installed():
+    assert env.is_package_installed("numpy")
+    assert env.is_package_installed("numpy>=0.0.1")
+    assert env.is_package_installed("numpy>=0.0.1,<=1000.0.0")
+    assert not env.is_package_installed("numpy<=0.0.1")
+    assert not env.is_package_installed("numpy>=1000.0.0")
+
+    numpy_version = env.get_package_version("numpy")
+    assert not env.is_package_installed("numpy==0.0.1")
+    assert env.is_package_installed(f"numpy=={numpy_version}")
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/utils/test_path.py
+++ b/tests/utils/test_path.py
@@ -31,7 +31,7 @@ def test_github_handler(tmpdir):
 
 def test_gdrive_handler(tmpdir):
     download_dir = tmpdir.mkdir("download")
-    gdrive_id = "14VQf4esuZVy_Xf6IUciBas81j0JpaqCb"
+    gdrive_id = "1fWgHNUljPrJj-97YPbbrqugSPnS2zXnx"
 
     handler = GoogleDriveHandler()
 

--- a/tests/utils/test_path.py
+++ b/tests/utils/test_path.py
@@ -1,7 +1,7 @@
 import os
 
 from meddlr.utils import env
-from meddlr.utils.path import GithubHandler, download_github_repository
+from meddlr.utils.path import GithubHandler, GoogleDriveHandler, download_github_repository
 
 # def test_meddlr_path_manager():
 #     pm = env.get_path_manager()
@@ -27,3 +27,21 @@ def test_github_handler(tmpdir):
     path = handler._get_local_path("github://annotations")
     assert str(path) == os.path.join(download_dir.strpath, "main", "annotations")
     assert os.path.isdir(path)
+
+
+def test_gdrive_handler(tmpdir):
+    download_dir = tmpdir.mkdir("download")
+    gdrive_id = "14VQf4esuZVy_Xf6IUciBas81j0JpaqCb"
+
+    handler = GoogleDriveHandler()
+
+    cache_file = download_dir / "sample-download.zip"
+    path = handler._get_local_path(
+        f"gdrive://https://drive.google.com/file/d/{gdrive_id}/view?usp=sharing",
+        cache_file=cache_file,
+    )
+    assert os.path.exists(path)
+
+    cache_file = download_dir / "sample-download2.zip"
+    path = handler._get_local_path(f"gdrive://{gdrive_id}", cache_file=cache_file)
+    assert os.path.exists(path)


### PR DESCRIPTION
This PR adds support for downloading public files from google drive using only the shared url. It uses the ``gdown`` library to perform the download.

### Usage
```python
from meddlr.utils import env

path_mgr = env.get_path_manager()

# Fetch, cache, and return local path for public google drive file
# 1. Full url (recommended)
file_path = path_mgr.get_local_path("gdrive://https://drive.google.com/file/d/14VQf4esuZVy_Xf6IUciBas81j0JpaqCb/view?usp=sharing")

# 2. id only
file_path = path_mgr.get_local_path("gdrive://14VQf4esuZVy_Xf6IUciBas81j0JpaqCb")

# 3. With download directive (requires full URL)
file_path = path_mgr.get_local_path("download://https://drive.google.com/file/d/14VQf4esuZVy_Xf6IUciBas81j0JpaqCb/view?usp=sharing")
```

The main work is done by the GoogleDriveHandler
```python
handler = GoogleDriveHandler()
handler.get_local_path("gdrive://https://drive.google.com/file/d/14VQf4esuZVy_Xf6IUciBas81j0JpaqCb/view?usp=sharing") 
# OR
handler.get_local_path("gdrive://14VQf4esuZVy_Xf6IUciBas81j0JpaqCb")
```

### Caveats
1. The file must be publicly viewable with a shared link
2. Dependency on ``gdown``
3. Only tested with files, not folders

### Todos

- [x] Add PathHandler for Google Drive files
- [x] Add PathHandler for generic downloading (currently only support GDrive download)
- [x] Add ``gdown`` to optional download
- [x] Add utility/configuration for specifying dependencies in published configs