### PR TITLE
bugfix: expand user path for default cache dir

### DIFF
--- a/meddlr/utils/cluster.py
+++ b/meddlr/utils/cluster.py
@@ -119,7 +119,9 @@ class Cluster:
     @property
     def cache_dir(self):
         path = self._cache_dir
-        path = os.environ.get("MEDDLR_CACHE_DIR", path if path else "~/cache/meddlr")
+        if not path:
+            path = os.path.expanduser("~/.cache/meddlr")
+        path = os.environ.get("MEDDLR_CACHE_DIR", path)
         return _PATH_MANAGER.get_local_path(path)
 
     def set(self, **kwargs):

--- a/tests/utils/test_cluster.py
+++ b/tests/utils/test_cluster.py
@@ -23,7 +23,7 @@ class TestCluster(unittest.TestCase):
         assert cluster.data_dir == "./datasets"
         assert cluster.datasets_dir == cluster.data_dir
         assert cluster.results_dir == "./results"
-        assert cluster.cache_dir == "~/cache/meddlr"
+        assert cluster.cache_dir == os.path.expanduser("~/.cache/meddlr")
 
     def test_set(self):
         """Test setting configuration properties."""


### PR DESCRIPTION
The default cache directory was `~/cache/meddlr`. Updated to `os.path.expanduser(~/.cache/meddlr)`