### PR TITLE
Support force downloading from gcp

### DIFF
--- a/meddlr/utils/path.py
+++ b/meddlr/utils/path.py
@@ -282,7 +282,7 @@ class DownloadHandler(GeneralPathHandler):
 
     Examples:
         >>> handler = DownloadHandler()
-        >>> handler.get_local_path("
+        >>> handler.get_local_path("download://https://drive.google.com/file/d/1fWgHNUljPrJj-97YPbbrqugSPnS2zXnx/view?usp=sharing")  # noqa: E501
     """
 
     PREFIX = "download://"
@@ -317,6 +317,28 @@ class DownloadHandler(GeneralPathHandler):
             return self.path_manager.get_local_path(f"gdrive://{path}", **kwargs)
         else:
             raise ValueError(f"Download not supported for url {path}")
+
+
+class ForceDownloadHandler(DownloadHandler):
+    """Like :cls:`DownloadHandler`, but always downloads (even if it is cached).
+
+    If the file is cached, it will be replaced by the downloaded version.
+
+    Examples:
+        >>> handler = ForceDownloadHandler()
+        >>> handler.get_local_path("force-download://https://drive.google.com/file/d/1fWgHNUljPrJj-97YPbbrqugSPnS2zXnx/view?usp=sharing")  # noqa: E501
+    """
+
+    PREFIX = "force-download://"
+
+    def _get_local_path(
+        self,
+        path: str,
+        **kwargs: Any,
+    ) -> str:
+        path = f"{DownloadHandler.PREFIX}{path[len(self.PREFIX) :]}"
+        kwargs.pop("force", None)
+        return super()._get_local_path(path, force=True, **kwargs)
 
 
 def download_github_repository(url, cache_path, branch_or_tag="main", force=False) -> str:
@@ -366,3 +388,4 @@ _path_manager.register_handler(GithubHandler(env.get_github_url(), default_branc
 _path_manager.register_handler(AnnotationsHandler())
 _path_manager.register_handler(GoogleDriveHandler())
 _path_manager.register_handler(DownloadHandler(_path_manager))
+_path_manager.register_handler(ForceDownloadHandler(_path_manager))

--- a/tests/utils/test_path.py
+++ b/tests/utils/test_path.py
@@ -1,7 +1,12 @@
 import os
 
 from meddlr.utils import env
-from meddlr.utils.path import GithubHandler, GoogleDriveHandler, download_github_repository
+from meddlr.utils.path import (
+    ForceDownloadHandler,
+    GithubHandler,
+    GoogleDriveHandler,
+    download_github_repository,
+)
 
 # def test_meddlr_path_manager():
 #     pm = env.get_path_manager()
@@ -39,9 +44,43 @@ def test_gdrive_handler(tmpdir):
     path = handler._get_local_path(
         f"gdrive://https://drive.google.com/file/d/{gdrive_id}/view?usp=sharing",
         cache_file=cache_file,
+        force=True,
     )
     assert os.path.exists(path)
+    mtime = os.path.getmtime(path)
+
+    path = handler._get_local_path(
+        f"gdrive://https://drive.google.com/file/d/{gdrive_id}/view?usp=sharing",
+        cache_file=cache_file,
+    )
+    mtime2 = os.path.getmtime(path)
+    assert mtime2 == mtime
 
     cache_file = download_dir / "sample-download2.zip"
     path = handler._get_local_path(f"gdrive://{gdrive_id}", cache_file=cache_file)
     assert os.path.exists(path)
+
+
+def test_force_download(tmpdir):
+    download_dir = tmpdir.mkdir("download")
+    gdrive_id = "1fWgHNUljPrJj-97YPbbrqugSPnS2zXnx"
+    cache_file = download_dir / "sample-download.zip"
+
+    path_manager = env.get_path_manager("meddlr_test")
+    path_manager.register_handler(GoogleDriveHandler())
+    handler = ForceDownloadHandler(path_manager)
+
+    path = handler._get_local_path(
+        f"force-download://https://drive.google.com/file/d/{gdrive_id}/view?usp=sharing",
+        cache_file=cache_file,
+    )
+    assert os.path.exists(path)
+    mtime = os.path.getmtime(path)
+
+    path = handler._get_local_path(
+        f"force-download://https://drive.google.com/file/d/{gdrive_id}/view?usp=sharing",
+        cache_file=cache_file,
+    )
+    mtime2 = os.path.getmtime(path)
+
+    assert mtime2 != mtime


### PR DESCRIPTION
The `force-download://` directive when added in front of a url will force download the file

### Limitations
- only applies to gcp for now