### PR TITLE
bugfix: add support for multi-channel inputs for MR reconstruction models

### DIFF
--- a/meddlr/modeling/loss_computer.py
+++ b/meddlr/modeling/loss_computer.py
@@ -100,7 +100,7 @@ class BasicLossComputer(LossComputer):
         target = output["target"].to(pred.device)
 
         if self.renormalize_data:
-            normalization_args = {k: input.get(k, output[k]) for k in ["mean", "std"]}
+            normalization_args = {k: input.get(k, output.get(k, None)) for k in ["mean", "std"]}
             normalized = self._normalizer.undo(
                 image=pred,
                 target=target,

--- a/meddlr/modeling/meta_arch/cs_model.py
+++ b/meddlr/modeling/meta_arch/cs_model.py
@@ -19,8 +19,8 @@ from torch import nn
 
 import meddlr.ops.complex as cplx
 from meddlr.config.config import configurable
+from meddlr.forward.mri import SenseModel
 from meddlr.utils.general import move_to_device
-from meddlr.utils.transforms import SenseModel
 
 from .build import META_ARCH_REGISTRY
 

--- a/meddlr/modeling/meta_arch/denoising.py
+++ b/meddlr/modeling/meta_arch/denoising.py
@@ -7,10 +7,10 @@ from torch import nn
 import meddlr.ops.complex as cplx
 from meddlr.config.config import configurable
 from meddlr.data.transforms.noise import NoiseModel
+from meddlr.forward.mri import SenseModel
 from meddlr.modeling.meta_arch.build import META_ARCH_REGISTRY, build_model
 from meddlr.utils.events import get_event_storage
 from meddlr.utils.general import move_to_device
-from meddlr.utils.transforms import SenseModel
 
 __all__ = ["DenoisingModel"]
 

--- a/meddlr/modeling/meta_arch/ssdu.py
+++ b/meddlr/modeling/meta_arch/ssdu.py
@@ -4,13 +4,13 @@ from torch import nn
 
 import meddlr.ops as oF
 from meddlr.config.config import configurable
+from meddlr.forward.mri import SenseModel
 from meddlr.modeling.meta_arch.build import META_ARCH_REGISTRY, build_model
 from meddlr.ops import complex as cplx
 from meddlr.transforms.base.mask import KspaceMaskTransform
 from meddlr.transforms.gen.mask import RandomKspaceMask
 from meddlr.utils.events import get_event_storage
 from meddlr.utils.general import move_to_device
-from meddlr.utils.transforms import SenseModel
 
 
 @META_ARCH_REGISTRY.register()

--- a/meddlr/modeling/meta_arch/unet.py
+++ b/meddlr/modeling/meta_arch/unet.py
@@ -11,9 +11,9 @@ from torch.nn import functional as F
 
 import meddlr.ops.complex as cplx
 from meddlr.config.config import configurable
+from meddlr.forward.mri import SenseModel
 from meddlr.utils import transforms as T
 from meddlr.utils.events import get_event_storage
-from meddlr.utils.transforms import SenseModel
 
 from .build import META_ARCH_REGISTRY
 
@@ -337,7 +337,7 @@ class UnetModel(nn.Module):
             output = zf_image.reshape(zf_image.shape[:-2] + (-1,)).unsqueeze(-2)
         else:
             output = zf_image
-        output = zf_image.permute(0, 4, 1, 2, 3).squeeze(-1)
+        output = output.permute(0, 4, 1, 2, 3).squeeze(-1)
 
         # Run U-Net.
         output = self.base_forward(output)

--- a/meddlr/modeling/meta_arch/unrolled.py
+++ b/meddlr/modeling/meta_arch/unrolled.py
@@ -7,9 +7,9 @@ from torch import nn
 
 import meddlr.ops.complex as cplx
 from meddlr.config.config import configurable
+from meddlr.forward.mri import SenseModel
 from meddlr.utils.events import get_event_storage
 from meddlr.utils.general import move_to_device
-from meddlr.utils.transforms import SenseModel
 
 from ..layers.layers2D import ResNet
 from .build import META_ARCH_REGISTRY, build_model
@@ -134,7 +134,7 @@ class GeneralizedUnrolledCNN(nn.Module):
         A = inputs.get("signal_model", None)
         maps = inputs["maps"]
         num_maps_dim = -2 if cplx.is_complex_as_real(maps) else -1
-        if self.num_emaps != maps.size()[num_maps_dim]:
+        if self.num_emaps != maps.size()[num_maps_dim] and maps.size()[num_maps_dim] != 1:
             raise ValueError("Incorrect number of ESPIRiT maps! Re-prep data...")
 
         # Move step sizes to the right device.

--- a/meddlr/ops/complex.py
+++ b/meddlr/ops/complex.py
@@ -66,7 +66,7 @@ def is_complex_as_real(x):
         has a size of ``2`` because it is the real-imaginary channel or
         for some other reason.
     """
-    return x.size(-1) == 2
+    return not is_complex(x) and x.size(-1) == 2
 
 
 def conj(x):

--- a/meddlr/ops/fft.py
+++ b/meddlr/ops/fft.py
@@ -196,7 +196,23 @@ def ifftshift(x, dim=None):
 def _fft_template(
     data: torch.Tensor, kind, dim=None, norm="ortho", is_real: bool = None, centered: bool = True
 ) -> torch.Tensor:
-    """Template for fft operations."""
+    """Template for fft operations.
+
+    Args:
+        data (torch.Tensor): A tensor.
+        kind (str): Either ``'fft'`` or ``'ifft'``.
+        dim (int(s), optional): The dimension(s) along which to apply the operation.
+            Defaults to all dimensions.
+        norm (str, optional): The normalization method. Defaults to ``'ortho'``.
+        is_real (bool, optional): If ``True``, ``input`` is treated like a real-valued
+            tensor. If not specified, this is ``True`` only if ``data`` is not complex
+            and data is not inferred to be a real view of a complex tensor
+            (i.e. ``data.shape[-1] != 2``).
+        centered (bool, optional): If ``True``, apply centered FFT. Defaults to ``True``.
+
+    Returns:
+        torch.Tensor: The FFT (or IFFT) of the input.
+    """
     if isinstance(dim, int):
         dim = (dim,)
     if norm is True:

--- a/tests/forward/test_mri.py
+++ b/tests/forward/test_mri.py
@@ -49,3 +49,32 @@ class TestSenseModel(unittest.TestCase):
         out = A_new(kspace, adjoint=True)
         assert torch.allclose(out, expected)
         assert torch.allclose(A_new(out, adjoint=False), A(expected, adjoint=False))
+
+    def test_multichannel(self):
+        """Test multi-channel inputs."""
+        ky = 20
+        kz = 20
+        nc = 8
+        num_channels = 3
+        nm = 1
+        bsz = 5
+
+        kspace = torch.randn(bsz, ky, kz, nc, num_channels, dtype=torch.complex64)
+        maps = torch.rand(bsz, ky, kz, nc, nm, dtype=torch.complex64)
+        maps = maps / cplx.rss(maps, dim=-2).unsqueeze(-2)
+
+        A = SenseModel(maps)
+
+        expected = []
+        for c in range(num_channels):
+            expected.append(A(kspace[..., c], adjoint=True))
+        expected = torch.cat(expected, dim=-1)
+        out_image = A(kspace, adjoint=True)
+        assert torch.allclose(out_image, expected)
+
+        expected = []
+        for c in range(num_channels):
+            expected.append(A(out_image[..., c : c + 1], adjoint=False))
+        expected = torch.stack(expected, dim=-1)
+        out_kspace = A(out_image, adjoint=False)
+        assert torch.allclose(out_kspace, expected)

--- a/tests/forward/test_mri.py
+++ b/tests/forward/test_mri.py
@@ -78,6 +78,4 @@ class TestSenseModel(unittest.TestCase):
         expected = torch.stack(expected, dim=-1)
         out_kspace = A(out_image, adjoint=False)
         # both clauses required for CI to pass on python 3.7 - torch.allclose does not work
-        assert torch.allclose(out_kspace, expected) or torch.all(
-            torch.abs(out_kspace - expected) < 1e-7
-        )
+        assert torch.allclose(out_kspace, expected, atol=1e-5)

--- a/tests/forward/test_mri.py
+++ b/tests/forward/test_mri.py
@@ -77,4 +77,7 @@ class TestSenseModel(unittest.TestCase):
             expected.append(A(out_image[..., c : c + 1], adjoint=False))
         expected = torch.stack(expected, dim=-1)
         out_kspace = A(out_image, adjoint=False)
-        assert torch.allclose(out_kspace, expected)
+        # both clauses required for CI to pass on python 3.7 - torch.allclose does not work
+        assert torch.allclose(out_kspace, expected) or torch.all(
+            torch.abs(out_kspace - expected) < 1e-7
+        )


### PR DESCRIPTION
This PR adds minimal support for multi-channel inputs for MR reconstruction and patches runtime errors seen in the skm-tea repository. Additional support will be provided in future PRs.

Note, in the short term, the `SenseModel` will support multi-channel inputs when only one set of maps for each coil is estimated. This will be fixed in #18 

## Changelist
- [x] permute the input in GeneralizedUNet when channels are reshaped
- [x] migrate recon models to use meddlr.forward.mri.SenseRecon instead of meddlr.utils.transforms.SenseRecon (deprecated)
- [x] update SenseModel to resolve differences between multi-channel inputs and multiple maps