### PR TITLE
fix seeding for RandomMaskFunc1D

### DIFF
--- a/meddlr/data/transforms/subsample.py
+++ b/meddlr/data/transforms/subsample.py
@@ -242,7 +242,7 @@ class RandomMaskFunc1D(MaskFunc):
 
         self.center_fractions = center_fractions
         self.calib_size = calib_size
-        self.accelerations = accelerations
+        super().__init__(accelerations)
 
     def __call__(self, shape, seed=None, acceleration=None):
         """
@@ -259,12 +259,13 @@ class RandomMaskFunc1D(MaskFunc):
 
         if seed is not None:
             np_state = np.random.get_state()
+        rng = np.random.RandomState(seed) if seed is not None else self.rng
 
         num_rows = shape[1]
         num_cols = shape[2]
         if self.center_fractions:
             if isinstance(self.center_fractions, Sequence):
-                choice = np.random.randint(0, len(self.center_fractions))
+                choice = rng.randint(0, len(self.center_fractions))
                 center_fraction = self.center_fractions[choice]
             else:
                 center_fraction = self.center_fractions
@@ -276,7 +277,7 @@ class RandomMaskFunc1D(MaskFunc):
         # Create the mask
         num_low_freqs = int(round(num_cols * center_fraction))
         prob = (num_cols / acceleration - num_low_freqs) / (num_cols - num_low_freqs)
-        mask = np.random.uniform(size=num_cols) < prob
+        mask = rng.uniform(size=num_cols) < prob
         pad = (num_cols - num_low_freqs + 1) // 2
         mask[pad : pad + num_low_freqs] = True
 

--- a/tests/data/transforms/test_subsample.py
+++ b/tests/data/transforms/test_subsample.py
@@ -1,7 +1,8 @@
 import numpy as np
+import pytest
 import torch
 
-from meddlr.data.transforms.subsample import PoissonDiskMaskFunc
+from meddlr.data.transforms.subsample import PoissonDiskMaskFunc, RandomMaskFunc1D
 
 
 def test_poisson_disc():
@@ -18,3 +19,45 @@ def test_poisson_disc():
 
     # assert all close with 5% tolerance.
     assert np.allclose(torch.sum(builtin_mask).item() / np.prod(shape), 1 / acc, atol=5e-2)
+
+
+@pytest.mark.parametrize("acc", [4, 8])
+@pytest.mark.parametrize("cf", [0.04, 0.08])
+@pytest.mark.parametrize("shape", [(100, 100), (100, 200)])
+@pytest.mark.parametrize("seed", [0, 10000])
+def test_random1d_reproducibility(acc, cf, shape, seed):
+    shape = (1, *shape)
+    a = RandomMaskFunc1D(acc, center_fractions=(cf,))
+    b = RandomMaskFunc1D(acc, center_fractions=(cf,))
+
+    a_mask = a(shape, seed=seed, acceleration=acc)
+    a_mask2 = a(shape, seed=seed, acceleration=acc)
+    b_mask = b(shape, seed=seed, acceleration=acc)
+
+    assert torch.all(a_mask == a_mask2)
+    assert torch.all(a_mask == b_mask)
+
+    a_mask = a(shape, seed=seed, acceleration=acc)
+    np.random.seed(seed * 2 + 1)
+    a_mask2 = a(shape, seed=seed, acceleration=acc)
+    assert torch.all(a_mask == a_mask2)
+
+
+@pytest.mark.parametrize("acc", [4, 8])
+@pytest.mark.parametrize("cf", [0.04, 0.08])
+@pytest.mark.parametrize("shape", [(100, 100), (100, 200)])
+@pytest.mark.parametrize("seed", [0])
+def test_random1d_randomness(acc, cf, shape, seed):
+    np.random.seed(seed)
+
+    shape = (1, *shape)
+    a = RandomMaskFunc1D(acc, center_fractions=(cf,))
+    seeds = np.random.randint(0, 2 ** 32, size=100)
+
+    a_mask = a(shape, seed=seed, acceleration=acc)
+    for s in seeds:
+        a_mask2 = a(shape, seed=s, acceleration=acc)
+        if torch.any(a_mask != a_mask2):
+            return
+
+    assert False


### PR DESCRIPTION
`RandomMaskFunc1D` was producing the same mask regardless of the seed - this fix makes it so that individual seeds create different masks for different scans