### PR TITLE
tempfix: set upperbound on torchmetrics version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,5 +11,5 @@ tqdm
 scikit-image>=0.18.2
 pandas
 silx
-torchmetrics>=0.5.1
+torchmetrics>=0.5.1,<0.7.0
 omegaconf

--- a/setup.py
+++ b/setup.py
@@ -98,7 +98,7 @@ setup(
         "silx",
         "tqdm",
         "omegaconf",
-        "torchmetrics>=0.5.1",
+        "torchmetrics>=0.5.1,<0.7.0",
         "iopath",
         "packaging",
     ],

--- a/tests/forward/test_mri.py
+++ b/tests/forward/test_mri.py
@@ -70,7 +70,7 @@ class TestSenseModel(unittest.TestCase):
             expected.append(A(kspace[..., c], adjoint=True))
         expected = torch.cat(expected, dim=-1)
         out_image = A(kspace, adjoint=True)
-        assert torch.allclose(out_image, expected)
+        assert torch.allclose(out_image, expected, atol=1e-5)
 
         expected = []
         for c in range(num_channels):


### PR DESCRIPTION
torchmetrics had soem breaking changes with the 0.7.0 version. as a temporary fix set an upper bound on the torchmetrics version. A long term solution will be applied when fixing #23