### PR TITLE
Add support for retrying reading for a file in HDF5Manager

### DIFF
--- a/meddlr/data/slice_dataset.py
+++ b/meddlr/data/slice_dataset.py
@@ -72,7 +72,7 @@ class SliceData(Dataset):
             self.mapping.update(keys)
         self._include_metadata = include_metadata
 
-        self._hdf5_manager = HDF5Manager(cache=False, num_retries=5, wait_time=1)
+        self._hdf5_manager = HDF5Manager(cache=False, max_attempts=5, wait_time=1)
 
     def groups(self, group_by):
         _groups = defaultdict(list)

--- a/tests/engine/test_model_zoo.py
+++ b/tests/engine/test_model_zoo.py
@@ -26,9 +26,9 @@ class TestModelZooExceptionsAndWarnings(unittest.TestCase):
 
     def test_get_model_from_zoo_dependency_warning(self):
         """Test that dependencies for configs get parsed."""
-        cfg_gdrive = "download://https://drive.google.com/file/d/1b_HU9p2iFUcQu7_8KadDEfhVer6v68Uj/view?usp=sharing"  # noqa: E501
+        cfg_url = "https://huggingface.co/datasets/arjundd/meddlr-data/raw/main/test-data/test-model/config-with-deps.yaml"  # noqa: E501
         with self.assertWarnsRegex(UserWarning, expected_regex=".*dependencies.*"):
-            get_model_from_zoo(cfg_gdrive, force_download=True)
+            get_model_from_zoo(cfg_url, force_download=True)
 
 
 @util.temp_env

--- a/tests/engine/test_model_zoo.py
+++ b/tests/engine/test_model_zoo.py
@@ -17,6 +17,8 @@ from meddlr.utils import env
 from .. import util
 
 REPO_DIR = pathlib.Path(os.path.abspath(os.path.join(os.path.dirname(__file__), "../..")))
+_SAMPLE_MODEL_CFG = "https://huggingface.co/datasets/arjundd/meddlr-data/raw/main/test-data/test-model/config.yaml"  # noqa: E501
+_SAMPLE_MODEL_WEIGHTS = "https://huggingface.co/datasets/arjundd/meddlr-data/resolve/main/test-data/test-model/model-cpu.pt"  # noqa: E501
 
 
 class TestModelZooExceptionsAndWarnings(unittest.TestCase):
@@ -34,24 +36,22 @@ def test_get_model_from_zoo():
     # Temporarily set cache dir to tmpdir
     os.environ["MEDDLR_CACHE_DIR"] = str(util.TEMP_CACHE_DIR / "test_get_model_from_zoo")
 
-    cfg_gdrive = "download://https://drive.google.com/file/d/1fRn5t4qGVVR6PyaRWPO6tAmug6-oTBjc/view?usp=sharing"  # noqa: E501
-    weights_gdrive = "download://https://drive.google.com/file/d/1BGARoUWLKg_DLfQN4AA2HnzktJzHaAy7/view?usp=sharing"  # noqa: E501
     path_mgr = env.get_path_manager()
 
-    model = get_model_from_zoo(cfg_gdrive, weights_gdrive, force_download=True)
+    model = get_model_from_zoo(_SAMPLE_MODEL_CFG, _SAMPLE_MODEL_WEIGHTS, force_download=True)
     assert isinstance(model, nn.Module)
-    weights_path = path_mgr.get_local_path(weights_gdrive)
+    weights_path = path_mgr.get_local_path(_SAMPLE_MODEL_WEIGHTS)
     weights = torch.load(weights_path)
     for name, param in model.named_parameters():
         assert name in weights
         assert torch.allclose(param, weights[name])
 
-    model2 = get_model_from_zoo(cfg_gdrive, force_download=True)
+    model2 = get_model_from_zoo(_SAMPLE_MODEL_CFG, force_download=True)
     assert isinstance(model2, nn.Module)
     assert type(model2) == type(model)
 
-    cfg = get_cfg().merge_from_file(path_mgr.get_local_path(cfg_gdrive))
-    model2 = get_model_from_zoo(cfg, weights_gdrive)
+    cfg = get_cfg().merge_from_file(path_mgr.get_local_path(_SAMPLE_MODEL_CFG))
+    model2 = get_model_from_zoo(cfg, _SAMPLE_MODEL_WEIGHTS)
     state_dict = model.state_dict()
     for name, param in model.named_parameters():
         assert name in state_dict
@@ -59,16 +59,14 @@ def test_get_model_from_zoo():
 
 
 def test_load_weights_shape_mismatch():
-    cfg_gdrive = "download://https://drive.google.com/file/d/1fRn5t4qGVVR6PyaRWPO6tAmug6-oTBjc/view?usp=sharing"  # noqa: E501
-    weights_gdrive = "download://https://drive.google.com/file/d/1BGARoUWLKg_DLfQN4AA2HnzktJzHaAy7/view?usp=sharing"  # noqa: E501
     path_mgr = env.get_path_manager()
 
-    cfg = get_cfg().merge_from_file(path_mgr.get_local_path(cfg_gdrive))
+    cfg = get_cfg().merge_from_file(path_mgr.get_local_path(_SAMPLE_MODEL_CFG))
     model = build_model(cfg)
     model.resnets[0] = None
-    model = load_weights(model, weights_gdrive, ignore_shape_mismatch=True)
+    model = load_weights(model, _SAMPLE_MODEL_WEIGHTS, ignore_shape_mismatch=True)
 
-    weights_path = path_mgr.get_local_path(weights_gdrive)
+    weights_path = path_mgr.get_local_path(_SAMPLE_MODEL_WEIGHTS)
     weights = torch.load(weights_path)
     for name, param in model.named_parameters():
         assert name in weights
@@ -76,15 +74,13 @@ def test_load_weights_shape_mismatch():
 
 
 def test_load_weights_find_device():
-    cfg_gdrive = "download://https://drive.google.com/file/d/1fRn5t4qGVVR6PyaRWPO6tAmug6-oTBjc/view?usp=sharing"  # noqa: E501
-    weights_gdrive = "download://https://drive.google.com/file/d/1BGARoUWLKg_DLfQN4AA2HnzktJzHaAy7/view?usp=sharing"  # noqa: E501
     path_mgr = env.get_path_manager()
 
-    cfg = get_cfg().merge_from_file(path_mgr.get_local_path(cfg_gdrive))
+    cfg = get_cfg().merge_from_file(path_mgr.get_local_path(_SAMPLE_MODEL_CFG))
     model = build_model(cfg)
-    model = load_weights(model, weights_gdrive, find_device=False)
+    model = load_weights(model, _SAMPLE_MODEL_WEIGHTS, find_device=False)
 
-    weights_path = path_mgr.get_local_path(weights_gdrive)
+    weights_path = path_mgr.get_local_path(_SAMPLE_MODEL_WEIGHTS)
     weights = torch.load(weights_path)
     for name, param in model.named_parameters():
         assert name in weights

--- a/tests/engine/test_model_zoo.py
+++ b/tests/engine/test_model_zoo.py
@@ -29,7 +29,11 @@ class TestModelZooExceptionsAndWarnings(unittest.TestCase):
             get_model_from_zoo(cfg_gdrive, force_download=True)
 
 
+@util.temp_env
 def test_get_model_from_zoo():
+    # Temporarily set cache dir to tmpdir
+    os.environ["MEDDLR_CACHE_DIR"] = str(util.TEMP_CACHE_DIR / "test_get_model_from_zoo")
+
     cfg_gdrive = "download://https://drive.google.com/file/d/1fRn5t4qGVVR6PyaRWPO6tAmug6-oTBjc/view?usp=sharing"  # noqa: E501
     weights_gdrive = "download://https://drive.google.com/file/d/1BGARoUWLKg_DLfQN4AA2HnzktJzHaAy7/view?usp=sharing"  # noqa: E501
     path_mgr = env.get_path_manager()

--- a/tests/evaluation/test_testing.py
+++ b/tests/evaluation/test_testing.py
@@ -1,4 +1,5 @@
 import os
+import tarfile
 from copy import deepcopy
 from pathlib import Path
 
@@ -51,13 +52,19 @@ def test_check_consistency():
 )
 def test_find_weights_basic(func_kwargs, expected_file):
     """Test that we can find the best weights from a basic experiment."""
+    exp_name = "basic-cpu"
+    cache_file = util.TEMP_CACHE_DIR / f"{exp_name}.tar.gz"
+    exp_dir = util.TEMP_CACHE_DIR / exp_name
+
     pm = env.get_path_manager()
-    exp_dir = pm.get_local_path(
-        "gdrive://https://drive.google.com/drive/folders/1XS6OfRSWYx_hX6AxefNuqbmSmCH0WtNp?usp=sharing",  # noqa: E501
-        cache=util.TEMP_CACHE_DIR / "basic-cpu",
+    tar_path = pm.get_local_path(
+        f"https://huggingface.co/datasets/arjundd/meddlr-data/resolve/main/test-data/test-exps/{exp_name}.tar.gz",  # noqa: E501
+        cache=cache_file,
     )
+    if not os.path.isdir(exp_dir):
+        with tarfile.open(tar_path, "r:gz") as tfile:
+            tfile.extractall(util.TEMP_CACHE_DIR)
     exp_dir = Path(exp_dir)
-    assert os.path.isdir(exp_dir)
 
     cfg = get_cfg()
     cfg.merge_from_file(exp_dir / "config.yaml")

--- a/tests/util.py
+++ b/tests/util.py
@@ -22,20 +22,22 @@ def temp_env(func):
     def wrapper(self, *args, **kwargs):
         old_env = dict(os.environ)
 
-        out = func(self, *args, **kwargs)
-
-        os.environ.clear()
-        os.environ.update(old_env)
+        try:
+            out = func(self, *args, **kwargs)
+        finally:
+            os.environ.clear()
+            os.environ.update(old_env)
         return out
 
     @wraps(func)
     def wrapper_func(*args, **kwargs):
         old_env = dict(os.environ)
 
-        out = func(*args, **kwargs)
-
-        os.environ.clear()
-        os.environ.update(old_env)
+        try:
+            out = func(*args, **kwargs)
+        finally:
+            os.environ.clear()
+            os.environ.update(old_env)
         return out
 
     return wrapper if "self" in inspect.signature(func).parameters else wrapper_func

--- a/tests/utils/test_path.py
+++ b/tests/utils/test_path.py
@@ -1,4 +1,5 @@
 import os
+import time
 
 import yaml
 
@@ -94,6 +95,7 @@ def test_force_download(tmpdir):
     )
     assert os.path.exists(path)
     mtime = os.path.getmtime(path)
+    time.sleep(0.1)
 
     path = handler._get_local_path(
         f"force-download://https://drive.google.com/file/d/{gdrive_id}/view?usp=sharing",

--- a/tests/utils/test_path.py
+++ b/tests/utils/test_path.py
@@ -81,26 +81,19 @@ def test_gdrive_handler(tmpdir):
 
 def test_force_download(tmpdir):
     download_dir = tmpdir.mkdir("download")
-    gdrive_id = "1fWgHNUljPrJj-97YPbbrqugSPnS2zXnx"
+    url = "force-download://https://huggingface.co/datasets/arjundd/meddlr-data/resolve/main/test-data/test-exps/basic-cpu.tar.gz"  # noqa: E501
     cache = download_dir / "sample-download.zip"
 
     path_manager = env.get_path_manager("meddlr_test")
-    path_manager.register_handler(GoogleDriveHandler())
     path_manager.register_handler(URLHandler(path_manager))
     handler = ForceDownloadHandler(path_manager)
 
-    path = handler._get_local_path(
-        f"force-download://https://drive.google.com/file/d/{gdrive_id}/view?usp=sharing",
-        cache=cache,
-    )
+    path = handler._get_local_path(url, cache=cache)
     assert os.path.exists(path)
     mtime = os.path.getmtime(path)
     time.sleep(0.1)
 
-    path = handler._get_local_path(
-        f"force-download://https://drive.google.com/file/d/{gdrive_id}/view?usp=sharing",
-        cache=cache,
-    )
+    path = handler._get_local_path(url, cache=cache)
     mtime2 = os.path.getmtime(path)
 
     assert mtime2 != mtime

--- a/tests/utils/test_path.py
+++ b/tests/utils/test_path.py
@@ -40,29 +40,19 @@ def test_github_handler(tmpdir):
 
 def test_gdrive_handler(tmpdir):
     download_dir = tmpdir.mkdir("download")
-    gdrive_id = "1fWgHNUljPrJj-97YPbbrqugSPnS2zXnx"
 
     handler = GoogleDriveHandler(cache_dir=tmpdir)
 
-    cache = download_dir / "sample-download.zip"
-    path = handler._get_local_path(
-        f"gdrive://https://drive.google.com/file/d/{gdrive_id}/view?usp=sharing",
-        cache=cache,
-        force=True,
-    )
+    # File
+    url = "gdrive://https://drive.google.com/file/d/1fWgHNUljPrJj-97YPbbrqugSPnS2zXnx/view?usp=sharing"  # noqa: E501
+    cache = download_dir / "hello-world.txt"
+    path = handler._get_local_path(url, cache=cache)
     assert os.path.exists(path)
     mtime = os.path.getmtime(path)
 
-    path = handler._get_local_path(
-        f"gdrive://https://drive.google.com/file/d/{gdrive_id}/view?usp=sharing",
-        cache=cache,
-    )
+    path = handler._get_local_path(url, cache=cache)
     mtime2 = os.path.getmtime(path)
     assert mtime2 == mtime
-
-    cache = download_dir / "sample-download2.zip"
-    path = handler._get_local_path(f"gdrive://{gdrive_id}", cache=cache)
-    assert os.path.exists(path)
 
     # Folder
     folder_url = "gdrive://https://drive.google.com/drive/folders/1UosSskt3H61wcIGUNehhsYoHNBmk-bGi?usp=sharing"  # noqa: E501


### PR DESCRIPTION
Network file systems (NFS) can have a volatile connection when multiple machines are accessing the same data, particularly for HDF5 files. To mitigate this issue, HDF5Manager now contains an init argument `max_attempts`, which can be set to a value greater than 1 to retry opening an HDF5 file and reading data. The `wait_time` argument defines the number of seconds to wait between retry attempts.