### PR TITLE
add LayerInfo

### DIFF
--- a/meddlr/modeling/layers/build.py
+++ b/meddlr/modeling/layers/build.py
@@ -1,4 +1,5 @@
-from typing import Union
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional, Tuple, Union
 
 from fvcore.common.registry import Registry
 from torch import nn
@@ -116,3 +117,97 @@ def get_layer_kind(layer_type: Union[type, str]) -> str:
         return "dropout"
 
     return "unknown"
+
+
+_LayerInfoInitKwargsDict = Dict[str, Any]
+_LayerInfoInitKwargsFlatSequence = Union[List[Any], Tuple[Any]]
+_NestedInnerArgs = Tuple[str, Any]
+_LayerInfoInitKwargsNestedSequence = Union[List[_NestedInnerArgs], Tuple[_NestedInnerArgs, ...]]
+_LayerInfoInitKwargsType = Union[
+    _LayerInfoInitKwargsDict, _LayerInfoInitKwargsFlatSequence, _LayerInfoInitKwargsNestedSequence
+]
+
+LayerInfoType = Union[
+    str, Dict[str, _LayerInfoInitKwargsType], Tuple[str, _LayerInfoInitKwargsType]
+]
+
+
+@dataclass
+class LayerInfo:
+    """Dataclass for managing layer information."""
+
+    name: str  # name of the layer
+    dimension: Optional[int] = None  # The dimension of the layer.
+    init_kwargs: Dict[str, Any] = field(default_factory=dict)  # keyword args to initialize layer
+
+    @property
+    def kind(self) -> str:
+        """The layer kind."""
+        return get_layer_kind(self.ltype)
+
+    @property
+    def ltype(self) -> type:
+        """The layer type."""
+        return get_layer_type(self.name, dimension=self.dimension)
+
+    @classmethod
+    def format(cls, layer_info: LayerInfoType) -> "LayerInfo":
+        """Formats layer information from Python raw types to LayerInfo object.
+
+        Args:
+            layer_info:
+
+        Returns:
+            LayerInfo
+        """
+        if isinstance(layer_info, str):
+            return LayerInfo(name=layer_info, init_kwargs={})
+
+        if isinstance(layer_info, Dict):
+            if len(layer_info) != 1:
+                raise ValueError(
+                    "Dictionary format for LayerInfo can only have one key-value pair. "
+                    "e.g. {'dropout': {'p': 0.5}}"
+                )
+            name, init_kwargs = list(layer_info.items())[0]
+        elif isinstance(layer_info, (Tuple, List)):
+            if len(layer_info) != 2:
+                raise ValueError(
+                    "Sequence format for LayerInfo should be formatted as (name, init_kwargs) "
+                    "e.g. ('dropout': {'p': 0.5}), ('dropout', ('p', 0.5)"
+                )
+            name, init_kwargs = layer_info[0], layer_info[1]
+        else:
+            raise ValueError(f"Unsupported layer info format: {type(layer_info)}")
+
+        # Format init kwargs.
+        init_kwargs_err_message = (
+            "Unknown init_kwargs format. init_kwargs must follow one of these formats: "
+            "\n\t- dict: {key1: value1, key2: value2}"
+            "\n\t- flat sequence: [key1, value1, key2, value2, ...]"
+            "\n\t- nested sequence: [(key1, value1), (key2, value2), ...]"
+        )
+        if isinstance(init_kwargs, (Tuple, List)):
+            if all(isinstance(x, (Tuple, List)) and len(x) == 2 for x in init_kwargs):
+                # Nested sequence - i.e. [(key1, value1), (key2, value2), ...]
+                init_kwargs = {x[0]: x[1] for x in init_kwargs}
+            else:
+                if len(init_kwargs) % 2 != 0:
+                    raise ValueError(init_kwargs_err_message)
+                # Flat sequence - i.e. [key1, value1, key2, value2, ...]
+                init_kwargs = dict(zip(init_kwargs[::2], init_kwargs[1::2]))
+        if not isinstance(init_kwargs, Dict):
+            raise ValueError(init_kwargs_err_message)
+
+        return LayerInfo(name=name, init_kwargs=init_kwargs)
+
+    def build(self, *args, **kwargs) -> nn.Module:
+        """Builds the layer.
+
+        Args:
+            *args: Positional arguments for building the module.
+            **kwargs: Keyword arguments to pass to the layer's ``__init__``.
+                Note, these will override the init_kwargs of the layer if there
+                are conflicts.
+        """
+        return self.ltype(*args, **{**self.init_kwargs, **kwargs})

--- a/meddlr/modeling/meta_arch/generalized_unet.py
+++ b/meddlr/modeling/meta_arch/generalized_unet.py
@@ -203,9 +203,6 @@ class GeneralizedUNet(nn.Module):
             "dropout": cfg.DROPOUT,
         }
         block_order = cfg.get("BLOCK_ORDER", None)
-        import pdb
-
-        pdb.set_trace()
         if block_order is not None:
             init_args["block_order"] = block_order
         init_args.update(**kwargs)

--- a/meddlr/modeling/meta_arch/generalized_unet.py
+++ b/meddlr/modeling/meta_arch/generalized_unet.py
@@ -203,6 +203,9 @@ class GeneralizedUNet(nn.Module):
             "dropout": cfg.DROPOUT,
         }
         block_order = cfg.get("BLOCK_ORDER", None)
+        import pdb
+
+        pdb.set_trace()
         if block_order is not None:
             init_args["block_order"] = block_order
         init_args.update(**kwargs)

--- a/tests/modeling/layers/test_build.py
+++ b/tests/modeling/layers/test_build.py
@@ -1,7 +1,12 @@
+from typing import Any, Dict, Optional
+
+import numpy as np
+import pytest
+import torch
 from torch import nn
 
 from meddlr.modeling import layers
-from meddlr.modeling.layers.build import CUSTOM_LAYERS_REGISTRY, get_layer_type
+from meddlr.modeling.layers.build import CUSTOM_LAYERS_REGISTRY, LayerInfo, get_layer_type
 
 
 def test_pt_layers_type():
@@ -91,3 +96,170 @@ def test_custom_layer_conflicting_names():
     """Verify that lowercasing custom layers does not cause layer overlap."""
     custom_layer_names = {x.lower(): x for x in CUSTOM_LAYERS_REGISTRY._obj_map}
     assert len(custom_layer_names) == len(CUSTOM_LAYERS_REGISTRY._obj_map)
+
+
+@pytest.mark.parametrize(
+    "name,dimension,init_kwargs,expected_ltype,expected_lkind",
+    [
+        # Convolutional layers.
+        ["conv", 1, None, nn.Conv1d, "conv"],
+        ["conv", 2, None, nn.Conv2d, "conv"],
+        ["conv", 3, None, nn.Conv3d, "conv"],
+        ["convtranspose", 1, None, nn.ConvTranspose1d, "conv"],
+        ["convws", 2, None, layers.ConvWS2d, "conv"],
+        ["conv1d", None, None, nn.Conv1d, "conv"],
+        ["conv", 1, {}, nn.Conv1d, "conv"],
+        # Normalization layers.
+        ["batchnorm", 1, None, nn.BatchNorm1d, "norm"],
+        ["batchnorm", 2, None, nn.BatchNorm2d, "norm"],
+        ["batchnorm", 3, None, nn.BatchNorm3d, "norm"],
+        ["groupnorm", None, None, nn.GroupNorm, "norm"],
+        ["groupnorm", 1, None, nn.GroupNorm, "norm"],
+        ["instancenorm", 1, None, nn.InstanceNorm1d, "norm"],
+        ["instancenorm", 2, None, nn.InstanceNorm2d, "norm"],
+        ["instancenorm", 3, None, nn.InstanceNorm3d, "norm"],
+        ["layernorm", None, None, nn.LayerNorm, "norm"],
+        ["layernorm", 1, None, nn.LayerNorm, "norm"],
+        # Activation layers.
+        ["relu", None, None, nn.ReLU, "act"],
+        ["leakyrelu", None, None, nn.LeakyReLU, "act"],
+        ["leakyrelu", None, {"negative_slope": 0.2, "inplace": True}, nn.LeakyReLU, "act"],
+        # Dropout layers.
+        ["dropout", 1, None, nn.Dropout, "dropout"],
+        ["dropout", 2, None, nn.Dropout2d, "dropout"],
+        ["dropout", 3, None, nn.Dropout3d, "dropout"],
+        # Pooling layers.
+        # TODO: Add a pool layer kind.
+        ["maxpool", 1, None, nn.MaxPool1d, "unknown"],
+        ["maxpool", 2, None, nn.MaxPool2d, "unknown"],
+        ["maxpool", 3, None, nn.MaxPool3d, "unknown"],
+        ["maxunpool", 1, None, nn.MaxUnpool1d, "unknown"],
+        ["maxunpool", 2, None, nn.MaxUnpool2d, "unknown"],
+        ["maxunpool", 3, None, nn.MaxUnpool3d, "unknown"],
+        ["avgpool", 1, None, nn.AvgPool1d, "unknown"],
+        ["avgpool", 2, None, nn.AvgPool2d, "unknown"],
+        ["avgpool", 3, None, nn.AvgPool3d, "unknown"],
+    ],
+)
+def test_layer_info_properties(
+    name: str,
+    dimension: str,
+    init_kwargs: Optional[Dict[str, Any]],
+    expected_ltype: type,
+    expected_lkind: str,
+):
+    """Test that the layer info properties are correct."""
+    layer_info = LayerInfo(name=name, dimension=dimension, init_kwargs=init_kwargs)
+    assert layer_info.ltype == expected_ltype
+    assert layer_info.kind == expected_lkind
+    if init_kwargs:
+        assert layer_info.init_kwargs == init_kwargs
+
+
+@pytest.mark.parametrize(
+    "layer_info,expected_layer_info",
+    [
+        # Success cases.
+        ["conv1d", LayerInfo(name="conv1d")],
+        [
+            ("conv1d", {"kernel_size": 3, "stride": 2}),
+            LayerInfo(name="conv1d", init_kwargs={"kernel_size": 3, "stride": 2}),
+        ],
+        [
+            ("conv1d", ("kernel_size", 3, "stride", 2)),
+            LayerInfo(name="conv1d", init_kwargs={"kernel_size": 3, "stride": 2}),
+        ],
+        [
+            ("conv1d", (("kernel_size", 3), ("stride", 2))),
+            LayerInfo(name="conv1d", init_kwargs={"kernel_size": 3, "stride": 2}),
+        ],
+        [
+            ["conv1d", {"kernel_size": 3, "stride": 2}],
+            LayerInfo(name="conv1d", init_kwargs={"kernel_size": 3, "stride": 2}),
+        ],
+        [
+            ["conv1d", ["kernel_size", 3, "stride", 2]],
+            LayerInfo(name="conv1d", init_kwargs={"kernel_size": 3, "stride": 2}),
+        ],
+        [
+            ["conv1d", [["kernel_size", 3], ["stride", 2]]],
+            LayerInfo(name="conv1d", init_kwargs={"kernel_size": 3, "stride": 2}),
+        ],
+        [
+            {"conv1d": {"kernel_size": 3, "stride": 2}},
+            LayerInfo(name="conv1d", init_kwargs={"kernel_size": 3, "stride": 2}),
+        ],
+        [
+            {"conv1d": ["kernel_size", 3, "stride", 2]},
+            LayerInfo(name="conv1d", init_kwargs={"kernel_size": 3, "stride": 2}),
+        ],
+        [
+            {"conv1d": [["kernel_size", 3], ["stride", 2]]},
+            LayerInfo(name="conv1d", init_kwargs={"kernel_size": 3, "stride": 2}),
+        ],
+        # Failure cases.
+        [{"conv1d": {"kernel_size": 3}, "conv2d": {"kernel_size": 3}}, None],
+        [("conv1d", ("kernel_size", 3, ("stride", 2))), None],
+        [("conv1d", ("kernel_size", 3, "stride")), None],
+    ],
+)
+def test_layer_info_format(layer_info, expected_layer_info: Optional[LayerInfo]):
+    """Test formatting LayerInfo from raw types (typically from parsed yaml files)."""
+    if expected_layer_info is None:
+        with pytest.raises(ValueError):
+            obj = LayerInfo.format(layer_info)
+    else:
+        obj = LayerInfo.format(layer_info)
+        assert obj == expected_layer_info
+
+
+@torch.no_grad()
+@pytest.mark.parametrize(
+    "layer_info,expected_layer",
+    [
+        [
+            LayerInfo(name="leakyrelu", init_kwargs=dict(negative_slope=0.2)),
+            nn.LeakyReLU(negative_slope=0.2),
+        ],
+        [
+            LayerInfo(
+                name="conv",
+                dimension=1,
+                init_kwargs=dict(in_channels=2, out_channels=4, kernel_size=3),
+            ),
+            nn.Conv1d(in_channels=2, out_channels=4, kernel_size=3),
+        ],
+        [
+            LayerInfo(
+                name="conv1d",
+                init_kwargs=dict(in_channels=2, out_channels=4, kernel_size=3),
+            ),
+            nn.Conv1d(in_channels=2, out_channels=4, kernel_size=3),
+        ],
+        [
+            LayerInfo(
+                name="conv2d",
+                init_kwargs=dict(in_channels=2, out_channels=4, kernel_size=3),
+            ),
+            nn.Conv2d(in_channels=2, out_channels=4, kernel_size=3),
+        ],
+    ],
+)
+def test_layer_info_build(layer_info: LayerInfo, expected_layer: nn.Module):
+    """Test that the layer builds correctly."""
+
+    def tensor_to_shape(x):
+        if isinstance(x, torch.Tensor):
+            return x.shape
+        if isinstance(x, dict):
+            return type(x)({k: tensor_to_shape(v) for k, v in x.items()})
+        if isinstance(x, (list, tuple)):
+            return type(x)([tensor_to_shape(v) for v in x])
+        return x
+
+    layer = layer_info.build()
+    assert type(layer) == type(expected_layer)
+
+    layer_shape = tensor_to_shape(layer.__dict__)
+    expected = tensor_to_shape(expected_layer.__dict__)
+    np.testing.assert_equal(layer_shape, expected)


### PR DESCRIPTION
`LayerInfo` is a dataclass that allows for more modular control of the layers being built. This class provides two key functions:

- `format`: Creates a `LayerInfo` object from raw python types which are typically read from files (e.g. yaml/json)
- `build`: Builds the layer given the layer's `init_kwargs`