### PR TITLE
deprecate 3.6 support in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.6", "3.7", "3.8"]
+        python-version: ["3.7", "3.8", "3.9"]
         
     steps:
       - uses: actions/checkout@v2
@@ -41,7 +41,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: ["3.7", "3.8"]
+        python-version: ["3.7", "3.8", "3.9"]
         torchmetrics-version: ["0.6.0", "0.7.3", "latest"]
     env:
       TORCHMETRICS: ${{ matrix.torchmetrics-version }}

--- a/setup.py
+++ b/setup.py
@@ -104,6 +104,9 @@ EXTRAS = {
         "medpy",
         "pooch",
         "gdown",
+        # tifffile==2022.7.28 not reading scipy data.
+        # TODO (arjundd): Investigate tifffile issue.
+        "tifffile<=2022.5.4",
         # Documentation
         "sphinx",
         "sphinxcontrib-bibtex",


### PR DESCRIPTION
- deprecate 3.6 support in CI -  seeing C407 errors in Py3.6 linting which are not supported in later versions
- `tifffile<=2022.5.4` - tifffile==2022.7.28 causing issues with skimage data loading during testing