### PR TITLE
refactor conv block and generalized unet to use LayerInfo abstraction

### DIFF
--- a/tests/modeling/meta_arch/test_generalized_unet.py
+++ b/tests/modeling/meta_arch/test_generalized_unet.py
@@ -1,6 +1,8 @@
 import unittest
 
+import numpy as np
 import torch
+from torch import nn
 
 from meddlr.config import get_cfg
 from meddlr.modeling.meta_arch import GeneralizedUNet
@@ -26,3 +28,39 @@ class TestGeneralizedUnet(unittest.TestCase):
         x = torch.randn(1, 1, 128, 128)
         out = model(x)
         assert out.shape == (1, 2, 128, 128)
+
+    def test_build_with_order(self):
+        block_order = (
+            "conv",
+            "instancenorm",
+            ("leakyrelu", {"negative_slope": 0.1, "inplace": True}),
+            "conv",
+            "instancenorm",
+            ("leakyrelu", {"negative_slope": 0.2, "inplace": False}),
+        )
+        expected_types = (
+            nn.Conv2d,
+            nn.InstanceNorm2d,
+            nn.LeakyReLU,
+            nn.Conv2d,
+            nn.InstanceNorm2d,
+            nn.LeakyReLU,
+        )
+        expected_up_types = (nn.ConvTranspose2d, nn.InstanceNorm2d, nn.LeakyReLU)
+
+        model = GeneralizedUNet(
+            dimensions=2, in_channels=1, out_channels=1, channels=(32, 64), block_order=block_order
+        )
+
+        for block in model.down_blocks.values():
+            np.testing.assert_equal(tuple(type(x) for x in block), expected_types)
+            assert block[2].negative_slope == 0.1
+            assert block[2].inplace
+            assert block[5].negative_slope == 0.2
+            assert not block[5].inplace
+
+        for blocks in model.up_blocks.values():
+            conv_t = blocks[0]  # the transpose block
+            np.testing.assert_equal(tuple(type(x) for x in conv_t), expected_up_types)
+            assert conv_t[2].negative_slope == 0.1
+            assert conv_t[2].inplace


### PR DESCRIPTION
This PR refactors `SimpleConvBlockNd` block and `GeneralizedUNet` to use the `LayerInfo` abstraction.

NOTE: there is one implementation breaking PR. GeneralizedUNet's upsampling block will order the norm/activation based on the order in the original block. Previously the order was always `convtranspose -> act -> norm`.  Order of `act` and `norm` will be determined by which comes first in the `block_order`
