### PR TITLE
update torchvision affine resample -> interpolation

### DIFF
--- a/meddlr/transforms/base/spatial.py
+++ b/meddlr/transforms/base/spatial.py
@@ -91,7 +91,12 @@ class AffineTransform(GeometricMixin, Transform):
             img = TF.pad(img, padding=pad, padding_mode="reflect")
 
         img = TF.affine(
-            img, angle=angle, translate=translate, scale=scale, shear=shear, resample=2  # bilinear
+            img,
+            angle=angle,
+            translate=translate,
+            scale=scale,
+            shear=shear,
+            interpolation=TF.InterpolationMode.BILINEAR,
         )
 
         if self.pad_like == "MRAugment":

--- a/tests/transforms/base/test_spatial.py
+++ b/tests/transforms/base/test_spatial.py
@@ -17,7 +17,12 @@ class TestAffineTransform(unittest.TestCase):
         x = torch.randn(1, 3, 50, 50)
 
         expected_out = tvf.affine(
-            x, angle=angle, translate=translate, scale=scale, shear=[0.0, 0.0], resample=2
+            x,
+            angle=angle,
+            translate=translate,
+            scale=scale,
+            shear=[0.0, 0.0],
+            interpolation=tvf.InterpolationMode.BILINEAR,
         )
 
         tfm = AffineTransform(angle=angle, translate=translate, scale=scale)


### PR DESCRIPTION
`resample=2` arg is deprecated in `torchvision.functional.affine`. we switch to `interpolation=TF.InterpolationMode.BILINEAR,`