### PR TITLE
Add utilities for dynamic edge mask computation

### DIFF
--- a/meddlr/config/defaults.py
+++ b/meddlr/config/defaults.py
@@ -337,6 +337,8 @@ _C.TEST.VAL_METRICS.RECON = ()
 # Specify if you are getting OOM errors during evaluation.
 # Set to 0 to disable.
 _C.TEST.FLUSH_PERIOD = 0
+_C.TEST.POSTPROCESSOR = CN()
+_C.TEST.POSTPROCESSOR.NAME = ""  # e.g. "hard_dc" for hard data consistency
 
 # ---------------------------------------------------------------------------- #
 # Misc options

--- a/meddlr/data/slice_dataset.py
+++ b/meddlr/data/slice_dataset.py
@@ -157,18 +157,10 @@ class SliceData(Dataset):
         target = data["target"]
 
         fname = os.path.splitext(os.path.basename(file_path))[0]
-        masked_kspace, maps, target, mean, std, norm = self.transform(
-            kspace, maps, target, fname, slice_id, is_unsupervised, fixed_acc
-        )
+        vals = self.transform(kspace, maps, target, fname, slice_id, is_unsupervised, fixed_acc)
+        target = vals.pop("target", None)
 
-        vals = {
-            "kspace": masked_kspace,
-            "maps": maps,
-            "mean": mean,
-            "std": std,
-            "norm": norm,
-            "is_unsupervised": is_unsupervised,
-        }
+        vals["is_unsupervised"] = is_unsupervised
         if (
             hasattr(self.transform, "augmentor")
             and isinstance(self.transform, DataTransform)

--- a/meddlr/data/transforms/subsample.py
+++ b/meddlr/data/transforms/subsample.py
@@ -63,6 +63,37 @@ class MaskFunc:
         acceleration = self.accelerations[0] + accel_range * self.rng.rand()
         return acceleration
 
+    def get_edge_mask(self, kspace: torch.Tensor, out_shape: Sequence[int] = None) -> torch.Tensor:
+        """Get the mask of the edges of kspace that are not sampled.
+
+        ``True`` values indicate the point is an edge location.
+
+        To accelerate the scan, edges of kspace are often not sampled
+        or are zero-padded during reconstruction. This method returns
+        an estimate of these edges based on the kspace.
+
+        Different undersampling methods have different mechanisms for estimating
+        the edges.
+
+        This method should be applied on the fully-sampled kspace (when possible)
+        for most accurate edge estimation. It should also be applied prior to
+        any additional padding on the kspace (e.g. ZIP2). If padding is used,
+        the edge mask must be manually padded as well.
+
+        Args:
+            kspace (torch.Tensor): The kspace to estimate the edges of.
+                Shape depends on the implementation in the subclass.
+
+        Returns:
+            torch.Tensor: A mask of the edges of kspace.
+            out_shape: The optional shape of the output mask.
+                There will be some constraints on the shape based on the
+                subclass implementation. Most typically, it will require
+                that the spatial dimensions of the output_shape match
+                the spatial dimensions of the kspace.
+        """
+        raise NotImplementedError()
+
 
 class CacheableMaskMixin:
     def get_filename(self):
@@ -183,6 +214,40 @@ class PoissonDiskMaskFunc(CacheableMaskMixin, MaskFunc):
 
         return mask
 
+    def get_edge_mask(self, kspace: torch.Tensor, out_shape: Sequence[int] = None):
+        """See :method:`MaskFunc.get_edge_mask`.
+
+        Expected `kspace` shape (batch, ky, kz, ...).
+        """
+
+        if out_shape is not None and out_shape[1:3] != kspace.shape[1:3]:
+            raise ValueError("out_shape must have the same ky and kz dimensions as kspace.")
+
+        if out_shape is None:
+            out_shape = kspace.shape
+        h, w = kspace.shape[1:3]
+
+        # When crop corner is disabled, all edges are sampled.
+        if not self.crop_corner:
+            return torch.zeros(out_shape, dtype=torch.float32, device=kspace.device)
+
+        # The edges of the ellipse are not sampled.
+        # These points should be set to 1 in the training mask.
+        # y: the row dimension, x: the column dimension.
+        # Ellipse equation: (x - xc)^2 / w^2 + (y - yc)^2 / h^2 = 1
+        grid_y, grid_x = torch.meshgrid(
+            torch.arange(h, device=kspace.device, dtype=torch.float32),
+            torch.arange(w, device=kspace.device, dtype=torch.float32),
+            indexing="ij",
+        )
+        yc, xc = _get_center(h), _get_center(w)
+        outer_ellipse_mask = (grid_y - yc) ** 2 / (h / 2) ** 2 + (grid_x - xc) ** 2 / (
+            w / 2
+        ) ** 2 > 1
+
+        outer_ellipse_mask = outer_ellipse_mask.type(torch.float32)
+        return _reshape_or_tile(outer_ellipse_mask, shape=out_shape, ndim=2)
+
     def _get_args(self):
         return {
             "accelerations": self.accelerations,
@@ -293,6 +358,18 @@ class RandomMaskFunc1D(MaskFunc):
 
         return mask
 
+    # def get_edge_mask(self, kspace: torch.Tensor, out_shape: Sequence[int] = None):
+    #     """See :method:`MaskFunc.get_edge_mask`.
+
+    #     Expected `kspace` shape (batch, ky, kz, ...).
+    #     """
+    #     if out_shape is not None and out_shape[1:3] != kspace.shape[1:3]:
+    #         raise ValueError("out_shape must have the same ky and kz dimensions as kspace.")
+
+    #     mask = cplx.get_mask(kspace)
+    #     is_zero = mask.sum(dim=(0,1) + tuple(range(3, kspace.ndim))) == 0
+    #     is_zero_shifted = torch.Tensor([True] * )
+
 
 class MaskLoader(MaskFunc):
     """Loads masks from predefined file format instead of computing on the fly."""
@@ -327,6 +404,32 @@ class MaskLoader(MaskFunc):
 
         mask = mask.reshape(out_shape)
         return torch.from_numpy(mask)
+
+
+def _reshape_or_tile(x: torch.Tensor, shape: Sequence[int], ndim: int) -> torch.Tensor:
+    """Reshape the tensor to the output shape or k-space shape.
+
+    k-space shape will require tiling the tensor to match the
+    k-space shape.
+    """
+    leading_dims = ndim + 1  # number of spatial dimensions + batch dimension
+
+    # This is a broadcasted output shape, where all non-zero dimensions match
+    # the shape of the tensor and all other dimensions are 1.
+    shape_tensor = torch.as_tensor(shape)
+    if shape[:leading_dims] == (1, *x.shape) and all(shape_tensor[leading_dims:] == 1):
+        return x.reshape(shape)
+
+    leading_dims = ndim + 1  # number of spatial dimensions + batch dimension
+    extra_dims = len(shape) - (leading_dims)
+    mask_shape = (1,) + shape[1:leading_dims] + (1,) * extra_dims
+    x = x.reshape(mask_shape)
+    return x.repeat(shape[0], 1, 1, *shape[leading_dims:])
+
+
+def _get_center(size: int) -> float:
+    """Get the center of the matrix."""
+    return size // 2 if size % 2 == 1 else size // 2 - 0.5
 
 
 # ================================================================ #

--- a/meddlr/data/transforms/subsample.py
+++ b/meddlr/data/transforms/subsample.py
@@ -1,12 +1,15 @@
 import inspect
 import os
-from typing import Sequence
+from typing import List, Sequence, Union
 
 import numba as nb
 import numpy as np
 import sigpy.mri
 import torch
+import torch.nn.functional as F
 from fvcore.common.registry import Registry
+
+import meddlr.ops.complex as cplx
 
 MASK_FUNC_REGISTRY = Registry("MASK_FUNC")
 MASK_FUNC_REGISTRY.__doc__ = """
@@ -137,6 +140,14 @@ class RandomMaskFunc(MaskFunc):
         ] = torch.Tensor([1])
 
         return mask.reshape(out_shape)
+
+    def get_edge_mask(self, kspace: torch.Tensor, out_shape: Sequence[int] = None):
+        """See :method:`MaskFunc.get_edge_mask`.
+
+        Expected `kspace` shape (batch, ky, kz, ...).
+        """
+        # TODO: dims should be configured based on the number of dimenions in the input.
+        return get_cartesian_edge_mask(kspace, dims=(1, 2), out_shape=out_shape)
 
 
 @MASK_FUNC_REGISTRY.register()
@@ -358,17 +369,84 @@ class RandomMaskFunc1D(MaskFunc):
 
         return mask
 
-    # def get_edge_mask(self, kspace: torch.Tensor, out_shape: Sequence[int] = None):
-    #     """See :method:`MaskFunc.get_edge_mask`.
+    def get_edge_mask(self, kspace: torch.Tensor, out_shape: Sequence[int] = None):
+        """See :method:`MaskFunc.get_edge_mask`.
 
-    #     Expected `kspace` shape (batch, ky, kz, ...).
-    #     """
-    #     if out_shape is not None and out_shape[1:3] != kspace.shape[1:3]:
-    #         raise ValueError("out_shape must have the same ky and kz dimensions as kspace.")
+        Expected `kspace` shape (batch, ky, kz, ...).
+        """
+        # TODO: dims should be configured based on the number of dimenions in the input.
+        return get_cartesian_edge_mask(kspace, dims=(1, 2), out_shape=out_shape)
 
-    #     mask = cplx.get_mask(kspace)
-    #     is_zero = mask.sum(dim=(0,1) + tuple(range(3, kspace.ndim))) == 0
-    #     is_zero_shifted = torch.Tensor([True] * )
+
+def get_cartesian_edge_mask(
+    kspace: torch.Tensor,
+    dims: Union[int, Sequence[int]],
+    out_shape: Sequence[int] = None,
+    dtype=torch.float32,
+):
+    """See :method:`MaskFunc.get_edge_mask`.
+
+    Expected `kspace` shape (batch, ky, kz, ...).
+    """
+    if isinstance(dims, int):
+        dims = (dims,)
+    dims = tuple(dims)
+
+    if out_shape is None:
+        out_shape = kspace.shape
+    if any(out_shape[i] != kspace.shape[i] for i in (0,) + dims):
+        raise ValueError(
+            "out_shape must have the same shape as kspace along batch and `dims` dimensions."
+        )
+    if kspace.ndim != len(out_shape):
+        raise ValueError("out_shape must have the same number of dimensions as kspace.")
+
+    mask = cplx.get_mask(kspace)
+    non_edge_mask = torch.zeros(out_shape, dtype=torch.bool, device=kspace.device)
+    batch = kspace.shape[0]
+
+    # Slices for each dimension in the output mask.
+    # We will isolate areas in the slices that
+    sls = [[slice(None)] * batch for _ in range(kspace.ndim - 1)]
+    sls = [list(range(batch))] + sls  # add slice to index batch dimension
+    for dim in dims:
+        sls[dim] = _get_nonedge_indices_slice(mask, dim=dim)
+
+    # Set the non-edge mask to 1 in the slice region.
+    for sl in zip(*sls):
+        non_edge_mask[sl] = True
+    # Negate the non-edge mask to get the edge mask.
+    return (~non_edge_mask).type(dtype)
+
+
+def _get_nonedge_indices_slice(mask: torch.Tensor, dim: int) -> List[slice]:
+    """Get the slice of indices that correspond to non-edge region along the given dimension.
+
+    Args:
+        mask: A mask of shape (batch, ...).
+        dim: The dimension along which to get the slice.
+            The nonedge slice cannot be computed along the batch dimension (i.e. dim>0).
+
+    Return:
+        List[slice]: The slice of indices that correspond to non-edge region
+            for each example in the batch.
+    """
+    # If dim is negative, convert it to the positive index.
+    if dim < 0:
+        dim = mask.ndim + dim
+    reduce_idxs = [i for i in range(1, mask.ndim) if i != dim]
+    is_zero = mask.sum(reduce_idxs) == 0  # shape: (batch, dim)
+    is_zero = F.pad(is_zero, (1, 1), value=True)
+
+    sls = []
+    # For each example in the batch,
+    # determine the first and last non-zero indices.
+    for batch_idx in range(is_zero.shape[0]):
+        zero_offset = torch.where(~(is_zero[batch_idx, :-1] & is_zero[batch_idx, 1:]))[0]
+        i0 = zero_offset[0].cpu().item()
+        i1 = zero_offset[-1].cpu().item()
+        sls.append(slice(i0, i1))
+    return sls
 
 
 class MaskLoader(MaskFunc):

--- a/meddlr/data/transforms/transform.py
+++ b/meddlr/data/transforms/transform.py
@@ -342,9 +342,11 @@ class DataTransform:
         masked_kspace, mask = self._subsampler(
             kspace, mode="2D", seed=seed, acceleration=acceleration
         )
+
+        edge_mask = self._subsampler.edge_mask(kspace, mode="2D")
         postprocessing_mask = None
         if self._is_test and self._postprocessor:
-            postprocessing_mask = self._subsampler.edge_mask(kspace, mode="2D")
+            postprocessing_mask = edge_mask
             if self._postprocessor == "hard_dc_all":
                 postprocessing_mask = (postprocessing_mask + mask).bool().type(torch.float32)
 
@@ -393,6 +395,7 @@ class DataTransform:
             "mean": mean,
             "std": std,
             "norm": norm,
+            "edge_mask": edge_mask.squeeze(0),
         }
         if postprocessing_mask is not None:
             out["postprocessing_mask"] = postprocessing_mask.squeeze(0)

--- a/meddlr/evaluation/recon_evaluation.py
+++ b/meddlr/evaluation/recon_evaluation.py
@@ -15,6 +15,7 @@ from tqdm import tqdm
 import meddlr.utils.comm as comm
 from meddlr.data.transforms.transform import build_normalizer
 from meddlr.evaluation.scan_evaluator import ScanEvaluator, structure_scans
+from meddlr.forward.mri import hard_data_consistency
 from meddlr.metrics.build import build_metrics
 from meddlr.metrics.collection import MetricCollection
 from meddlr.ops import complex as cplx
@@ -97,6 +98,7 @@ class ReconEvaluator(ScanEvaluator):
         self._channel_names = channel_names
         self._structure_channel_by = structure_channel_by
         self._prefix = prefix
+        self._postprocess = cfg.TEST.POSTPROCESSOR.NAME
 
         if save_scans and (not output_dir or not aggregate_scans):
             raise ValueError("`output_dir` and `aggregate_scans` must be specified to save scans.")
@@ -180,6 +182,15 @@ class ReconEvaluator(ScanEvaluator):
 
         preds: torch.Tensor
         targets: torch.Tensor
+
+        # Hacky way to postprocess the targets with hard data consistency (if specified).
+        if "hard_dc" in self._postprocess:
+            outputs["pred"] = hard_data_consistency(
+                outputs["pred"],
+                acq_kspace=inputs["kspace"],
+                mask=inputs["postprocessing_mask"],
+                maps=inputs["maps"],
+            )
 
         if self._skip_rescale:
             # Do not rescale the outputs

--- a/meddlr/modeling/meta_arch/ssdu.py
+++ b/meddlr/modeling/meta_arch/ssdu.py
@@ -70,6 +70,7 @@ class SSDUModel(nn.Module):
         masker = self.masker
         kspace = inputs["kspace"].clone()
         mask = cplx.get_mask(kspace)
+        edge_mask = inputs["edge_mask"]
 
         tfm: KspaceMaskTransform = masker.get_transform(kspace)
         train_mask = tfm.generate_mask(kspace, channels_last=True)
@@ -77,7 +78,7 @@ class SSDUModel(nn.Module):
 
         # Pad the train mask so that all unacquired kspace points
         # are included in the train_mask.
-        train_mask = _pad_train_mask(mask, train_mask)
+        train_mask = (train_mask.type(torch.bool) | edge_mask.type(torch.bool)).type(torch.float32)
 
         # TODO (arjundd): See if we can remove this check for speed reasons.
         assert torch.all(loss_mask >= 0)
@@ -117,9 +118,9 @@ class SSDUModel(nn.Module):
             ), "unsupervised inputs should not be provided in eval mode"
             inputs = inputs.get("supervised", inputs)
             mask = cplx.get_mask(inputs["kspace"])
-            # FIXME (arjundd): Recommended by SSDU authors during test time as well.
-            # Why is this necessary during test time?
-            dc_mask = _pad_train_mask(mask, mask)
+            # The mask should be the union of the edge mask and the sampled data mask.
+            # https://github.com/byaman14/SSDU
+            dc_mask = (mask + inputs["edge_mask"]).bool().to(mask.dtype)
             inputs["mask"] = dc_mask
             # inputs["postprocessing_mask"] = dc_mask - mask
             return self.model(inputs)
@@ -200,44 +201,3 @@ class SSDUModel(nn.Module):
         masker.to(cfg.MODEL.DEVICE)
 
         return {"model": model, "masker": masker}
-
-
-def _pad_train_mask(original_mask: torch.Tensor, train_mask: torch.Tensor) -> torch.Tensor:
-    """Perform SSDU training mask padding.
-
-    In SSDU, all edge k-space points that are not acquired in the original
-    undersampling mask should be kept in the training mask. This is to
-    ensure appropriate data consistency with the unused points.
-
-    Args:
-        original_mask: The original undersampling mask.
-        train_mask: The training mask.
-
-    Returns:
-        torch.Tensor: The padded training mask.
-    """
-
-    def get_center(size: int) -> float:
-        """Get the center of the matrix."""
-        return size // 2 if size % 2 == 1 else size // 2 - 0.5
-
-    assert original_mask.shape[:-1] == train_mask.shape[:-1]
-    assert train_mask.shape[-1] in [1, original_mask.shape[-1]]
-
-    # This is only for PoissonDisc undersampling.
-    # The edges of the ellipse are not sampled.
-    # These points should be set to 1 in the training mask.
-    # y: the row dimension, x: the column dimension.
-    h, w = train_mask.shape[1:3]
-    grid_y, grid_x = torch.meshgrid(
-        torch.arange(h).to(train_mask.device), torch.arange(w).to(train_mask.device), indexing="ij"
-    )
-    # grid_y, grid_x = grid_y.to(train_mask.device), grid_x.to(train_mask.device)
-    yc, xc = get_center(h), get_center(w)
-    outer_ellipse_mask = (grid_y - yc) ** 2 / (h / 2) ** 2 + (grid_x - xc) ** 2 / (w / 2) ** 2 > 1
-    outer_ellipse_mask = outer_ellipse_mask.reshape(1, h, w, 1)
-    dtype = train_mask.dtype
-    train_mask = train_mask.type(torch.bool) | outer_ellipse_mask.type(torch.bool)
-    train_mask = train_mask.type(dtype)
-
-    return train_mask

--- a/tests/data/transforms/test_subsample.py
+++ b/tests/data/transforms/test_subsample.py
@@ -1,8 +1,10 @@
+from typing import Tuple
+
 import numpy as np
 import pytest
 import torch
 
-from meddlr.data.transforms.subsample import PoissonDiskMaskFunc, RandomMaskFunc1D
+from meddlr.data.transforms.subsample import PoissonDiskMaskFunc, RandomMaskFunc1D, _get_center
 
 
 def test_poisson_disc():
@@ -19,6 +21,66 @@ def test_poisson_disc():
 
     # assert all close with 5% tolerance.
     assert np.allclose(torch.sum(builtin_mask).item() / np.prod(shape), 1 / acc, atol=5e-2)
+
+
+@pytest.mark.parametrize("shape", [(100, 100), (320, 256)])
+@pytest.mark.parametrize("use_out_shape", [False, True])
+def test_poisson_disc_get_edge_mask(shape: Tuple[int], use_out_shape: bool):
+    """Verify the edge computation for the poisson disc method.
+
+    This should work with both square and rectangular images.
+
+    """
+    acc = 6
+    calib_size = 20
+    height, width = shape
+    shape = (1, height, width)  # (batch, height, width)
+
+    kspace = torch.randn(shape, dtype=torch.complex64)
+    masker = PoissonDiskMaskFunc(acc, calib_size)
+    out_shape = (*shape, 1, 1) if use_out_shape else None
+    edge_mask = masker.get_edge_mask(kspace, out_shape=out_shape)
+    if use_out_shape:
+        assert edge_mask.shape == out_shape
+    else:
+        assert edge_mask.shape == kspace.shape
+    edge_mask = edge_mask.squeeze()
+
+    # Points outside of ellipse should be 1.
+    coordinates = torch.where(edge_mask == 1)
+    coordinates = torch.stack(coordinates, axis=1)  # Shape: (N, 2)
+    radius = _elliptical_radius(coordinates, (height, width))
+    assert torch.all(radius > 1)
+
+    # Points inside/on the ellipse should be 0.
+    coordinates = torch.where(edge_mask == 0)
+    coordinates = torch.stack(coordinates, axis=1)  # Shape: (N, 2)
+    radius = _elliptical_radius(coordinates, (height, width))
+    assert torch.all(radius <= 1)
+
+
+def _elliptical_radius(coordinates: torch.Tensor, shape: Tuple[int]) -> torch.Tensor:
+    """Compute the elliptical radius for a given coordinate.
+
+    Args:
+        coordinates: The coordinates. Shape: (N, dims)
+        shape: The shape of matrix. Length should equal ``dims``.
+
+    Returns:
+        torch.Tensor: The radius. Shape: (N,)
+    """
+    assert len(shape) == coordinates.shape[1]
+    center = torch.tensor([_get_center(x) for x in shape])
+    # The centered coordinates.
+    coords = (coordinates - center) ** 2
+    radius = torch.sum(coords / (torch.as_tensor(shape) / 2) ** 2, axis=1)
+    return radius
+
+
+def test_get_center():
+    """Verify that the zero-indexed center is returned."""
+    assert _get_center(3) == 1
+    assert _get_center(4) == 1.5
 
 
 @pytest.mark.parametrize("acc", [4, 8])

--- a/tests/forward/test_mri.py
+++ b/tests/forward/test_mri.py
@@ -4,8 +4,10 @@ import torch
 
 import meddlr.ops.complex as cplx
 import meddlr.utils.transforms as T
-from meddlr.forward import SenseModel
+from meddlr.forward.mri import SenseModel, hard_data_consistency
 from meddlr.utils import env
+
+from ..transforms.mock import generate_mock_mri_data
 
 
 class TestSenseModel(unittest.TestCase):
@@ -79,3 +81,14 @@ class TestSenseModel(unittest.TestCase):
         out_kspace = A(out_image, adjoint=False)
         # both clauses required for CI to pass on python 3.7 - torch.allclose does not work
         assert torch.allclose(out_kspace, expected, atol=1e-5)
+
+
+def test_hard_data_consistency_trivial():
+    ky = 20
+    kz = 20
+    nc = 8
+
+    kspace, maps, target = generate_mock_mri_data(ky=ky, kz=kz, nc=nc, nm=1, bsz=1)
+    mask = torch.ones_like(kspace)
+    recon = hard_data_consistency(target, kspace, mask=mask, maps=maps)
+    assert torch.allclose(recon, target, atol=1e-5)


### PR DESCRIPTION
Edge k-space is defined as the k-space along the edges of the matrix that is not sampled. An example of edge k-space for the Poisson Disc undersampling pattern with `crop_corners=True` is shown below

<img width="726" alt="image" src="https://user-images.githubusercontent.com/12801331/191421242-1a8c0070-73c1-43f3-a706-fc9501f52539.png">

We often want to know the edge k-space for certain methods (SSDU, hard data consistency postprocessing, etc.). This PR provides utilities for dynamically computing the edge k-space based on the type of undersampling pattern used.

 