### PR TITLE
Update linting and fix pandas numeric bug

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -2,7 +2,7 @@
 # Keep in sync with setup.cfg which is used for source packages.
 
 [flake8]
-ignore = B011, B028, B904, B905, B907, B950, W503, E203, E221, C901, C408, W605
+ignore = B011, B028, B904, B905, B907, B950, W503, E203, E221, C901, C408, W605, C416
 max-line-length = 100
 max-complexity = 18
 select = B,C,E,F,W,T4,B9

--- a/datasets/utils/data_partition.py
+++ b/datasets/utils/data_partition.py
@@ -316,11 +316,9 @@ def approximately_split_weighted(
     assert np.sum([len(x) for x in outputs]) == num_values
     assert len(outputs) == len(split_percentages)
     assert all(
-        [
-            len(set(outputs[i]) & set(outputs[j])) == 0
-            for i in range(len(outputs))
-            for j in range(i + 1, len(outputs))
-        ]
+        len(set(outputs[i]) & set(outputs[j])) == 0
+        for i in range(len(outputs))
+        for j in range(i + 1, len(outputs))
     )
 
     for x in outputs:

--- a/meddlr/data/build.py
+++ b/meddlr/data/build.py
@@ -241,11 +241,9 @@ def build_recon_train_loader(cfg, dataset_type=None):
 
     train_loader = DataLoader(
         dataset=train_data,
-        num_workers=cfg.DATALOADER.NUM_WORKERS,
         num_workers=num_workers,
         pin_memory=True,
         collate_fn=collate_fn,
-        prefetch_factor=cfg.DATALOADER.PREFETCH_FACTOR,
         prefetch_factor=prefetch_factor,
         **dl_kwargs,
     )

--- a/meddlr/data/build.py
+++ b/meddlr/data/build.py
@@ -13,6 +13,7 @@ from meddlr.data.samplers.build import build_train_sampler, build_val_sampler
 from meddlr.data.slice_dataset import SliceData
 from meddlr.data.transforms import transform as T
 from meddlr.data.transforms.subsample import build_mask_func
+from meddlr.utils import env
 
 __all__ = ["build_recon_train_loader", "build_recon_val_loader"]
 
@@ -233,12 +234,19 @@ def build_recon_train_loader(cfg, dataset_type=None):
             "drop_last": cfg.DATALOADER.DROP_LAST,
         }
 
+    num_workers = cfg.DATALOADER.NUM_WORKERS
+    prefetch_factor = cfg.DATALOADER.PREFETCH_FACTOR
+    if env.pt_version() >= "2.0" and num_workers == 0:
+        prefetch_factor = None
+
     train_loader = DataLoader(
         dataset=train_data,
         num_workers=cfg.DATALOADER.NUM_WORKERS,
+        num_workers=num_workers,
         pin_memory=True,
         collate_fn=collate_fn,
         prefetch_factor=cfg.DATALOADER.PREFETCH_FACTOR,
+        prefetch_factor=prefetch_factor,
         **dl_kwargs,
     )
     return train_loader

--- a/meddlr/data/data_utils.py
+++ b/meddlr/data/data_utils.py
@@ -249,7 +249,7 @@ def structure_patches(
     assert coords_arr.ndim == 2
     stack_shape = tuple(np.max(coords_arr[:, c]).item() + 1 for c in range(coords_arr.shape[1]))
 
-    struct = np.empty(stack_shape, dtype=np.object)
+    struct = np.empty(stack_shape, dtype="object")
     for coord, patch in zip(coords, patches):
         struct[coord] = patch
     if any(x is None for x in struct.flatten()):

--- a/meddlr/metrics/collection.py
+++ b/meddlr/metrics/collection.py
@@ -58,7 +58,7 @@ class MetricCollection(_MetricCollection):
         if len(np.unique(df["category"])) > 1:
             df["Metric"] = df["Metric"] + "/" + df["category"]
         df = df.drop(columns="category")
-        values = df.groupby(by=group_by).mean()
+        values = df.groupby(by=group_by).mean(numeric_only=True)
         return values.to_dict()["value"]
 
     def summary(self, sync_dist: bool = True) -> str:

--- a/tests/modeling/blocks/test_basic.py
+++ b/tests/modeling/blocks/test_basic.py
@@ -16,10 +16,8 @@ class TestSimpleConvBlock(unittest.TestCase):
         # 2D
         block = SimpleConvBlockNd(16, 32, 3, 2, dropout=0.5)
         assert all(
-            [
-                isinstance(x, cls)
-                for x, cls in zip(block, [nn.Conv2d, nn.BatchNorm2d, nn.ReLU, nn.Dropout2d])
-            ]
+            isinstance(x, cls)
+            for x, cls in zip(block, [nn.Conv2d, nn.BatchNorm2d, nn.ReLU, nn.Dropout2d])
         ), f"Got {block}"
         assert block[0].in_channels == 16
         assert block[0].out_channels == 32
@@ -28,10 +26,8 @@ class TestSimpleConvBlock(unittest.TestCase):
         # 3D
         block = SimpleConvBlockNd(16, 32, 3, 3, dropout=0.5)
         assert all(
-            [
-                isinstance(x, cls)
-                for x, cls in zip(block, [nn.Conv3d, nn.BatchNorm3d, nn.ReLU, nn.Dropout3d])
-            ]
+            isinstance(x, cls)
+            for x, cls in zip(block, [nn.Conv3d, nn.BatchNorm3d, nn.ReLU, nn.Dropout3d])
         ), f"Got {block}"
         assert block[0].in_channels == 16
         assert block[0].out_channels == 32
@@ -47,7 +43,7 @@ class TestSimpleConvBlock(unittest.TestCase):
             order=("convws", ("groupnorm", {"num_groups": 8}), "relu"),
         )
         assert all(
-            [isinstance(x, cls) for x, cls in zip(block, [ConvWS2d, nn.GroupNorm, nn.ReLU])]
+            isinstance(x, cls) for x, cls in zip(block, [ConvWS2d, nn.GroupNorm, nn.ReLU])
         ), f"Got {block}"
         assert block[0].in_channels == 16
         assert block[0].out_channels == 32


### PR DESCRIPTION
- update linting with flake8-bugbear and flake8-comprehensions
- Resolves #88 
- Use `prefetch_factor=None` for pytorch 2.0 when `num_workers == 0`