### PR TITLE
Config supports nested string formatting

### DIFF
--- a/meddlr/config/defaults.py
+++ b/meddlr/config/defaults.py
@@ -437,3 +437,10 @@ _C.DESCRIPTION.EXP_NAME = ""
 # Tags associated with experiment.
 # e.g. "fastmri_knee_mc" for fastMRI dataset; "unrolled" for using unrolled network; etc.
 _C.DESCRIPTION.TAGS = ()
+
+# ---------------------------------------------------------------------------- #
+# Miscellaneous
+# This is a free field that can be used to add any extra config fields without
+# affecting loading of any particular config.
+# ---------------------------------------------------------------------------- #
+_C.MISC = CN(new_allowed=True)

--- a/tests/config/test_config.py
+++ b/tests/config/test_config.py
@@ -1,52 +1,62 @@
-import unittest
-
 import pytest
 
 from meddlr.config.config import get_cfg
 
 
-class TestConfig(unittest.TestCase):
-    def test_format_fields(self):
-        cfg = get_cfg()
-        cfg.DESCRIPTION.BRIEF = 'f"seed={SEED},project={DESCRIPTION.PROJECT_NAME}"'
-        cfg.format_fields()
-        assert cfg.DESCRIPTION.BRIEF == f"seed={cfg.SEED},project={cfg.DESCRIPTION.PROJECT_NAME}"
+def test_format_fields():
+    cfg = get_cfg()
+    cfg.DESCRIPTION.BRIEF = 'f"seed={SEED},project={DESCRIPTION.PROJECT_NAME}"'
+    cfg.format_fields()
+    assert cfg.DESCRIPTION.BRIEF == f"seed={cfg.SEED},project={cfg.DESCRIPTION.PROJECT_NAME}"
 
-        cfg = get_cfg()
-        cfg.DESCRIPTION.BRIEF = 'f"{SEED},project={DESCRIPTION.PROJECT_NAME}"'
-        cfg.format_fields()
-        assert cfg.DESCRIPTION.BRIEF == f"{cfg.SEED},project={cfg.DESCRIPTION.PROJECT_NAME}"
+    cfg = get_cfg()
+    cfg.DESCRIPTION.BRIEF = 'f"{SEED},project={DESCRIPTION.PROJECT_NAME}"'
+    cfg.format_fields()
+    assert cfg.DESCRIPTION.BRIEF == f"{cfg.SEED},project={cfg.DESCRIPTION.PROJECT_NAME}"
 
-        cfg = get_cfg()
-        cfg.DESCRIPTION.BRIEF = 'f"{SEED},project={DESCRIPTION.PROJECT_NAME}-today"'
-        cfg.format_fields()
-        assert cfg.DESCRIPTION.BRIEF == f"{cfg.SEED},project={cfg.DESCRIPTION.PROJECT_NAME}-today"
+    cfg = get_cfg()
+    cfg.DESCRIPTION.BRIEF = 'f"{SEED},project={DESCRIPTION.PROJECT_NAME}-today"'
+    cfg.format_fields()
+    assert cfg.DESCRIPTION.BRIEF == f"{cfg.SEED},project={cfg.DESCRIPTION.PROJECT_NAME}-today"
 
-        cfg = get_cfg()
-        cfg.AUG_TRAIN.UNDERSAMPLE.ACCELERATIONS = (6, 8)
-        cfg.DESCRIPTION.BRIEF = (
-            'f"{AUG_TRAIN.UNDERSAMPLE.ACCELERATIONS},project={DESCRIPTION.PROJECT_NAME}-today"'
-        )
-        cfg.format_fields(unroll=True)
-        expected = "{},project={}-today".format(
-            "-".join(str(x) for x in cfg.AUG_TRAIN.UNDERSAMPLE.ACCELERATIONS),
-            cfg.DESCRIPTION.PROJECT_NAME,
-        )
-        assert cfg.DESCRIPTION.BRIEF == expected
+    cfg = get_cfg()
+    cfg.AUG_TRAIN.UNDERSAMPLE.ACCELERATIONS = (6, 8)
+    cfg.DESCRIPTION.BRIEF = (
+        'f"{AUG_TRAIN.UNDERSAMPLE.ACCELERATIONS},project={DESCRIPTION.PROJECT_NAME}-today"'
+    )
+    cfg.format_fields(unroll=True)
+    expected = "{},project={}-today".format(
+        "-".join(str(x) for x in cfg.AUG_TRAIN.UNDERSAMPLE.ACCELERATIONS),
+        cfg.DESCRIPTION.PROJECT_NAME,
+    )
+    assert cfg.DESCRIPTION.BRIEF == expected
 
-    def test_get_recursive(self):
-        cfg = get_cfg()
-        cfg.DESCRIPTION.BRIEF = "foobar"
 
-        assert cfg.get_recursive("DESCRIPTION.BRIEF") == "foobar"
-        assert cfg.get_recursive("DESCRIPTION.FOO", None) is None
-        with pytest.raises(KeyError):
-            cfg.get_recursive("DESCRIPTION.FOO")
+def test_format_fields_nested():
+    """Format fields inside lists and tuples."""
+    cfg = get_cfg()
+    cfg.DESCRIPTION.TAGS = ['f"seed={SEED},project={DESCRIPTION.PROJECT_NAME}"', "foobar"]
+    cfg.format_fields()
+    assert cfg.DESCRIPTION.TAGS == [
+        f"seed={cfg.SEED},project={cfg.DESCRIPTION.PROJECT_NAME}",
+        "foobar",
+    ]
 
-    def test_get_recursive_with_list(self):
-        cfg = get_cfg()
-        cfg.DESCRIPTION.BRIEF = "foobar"
 
-        assert cfg.get_recursive("DESCRIPTION.BRIEF[0]") == "f"
-        with pytest.raises(IndexError):
-            cfg.get_recursive("DESCRIPTION.BRIEF[1000]")
+def test_get_recursive():
+    cfg = get_cfg()
+    cfg.DESCRIPTION.BRIEF = "foobar"
+
+    assert cfg.get_recursive("DESCRIPTION.BRIEF") == "foobar"
+    assert cfg.get_recursive("DESCRIPTION.FOO", None) is None
+    with pytest.raises(KeyError):
+        cfg.get_recursive("DESCRIPTION.FOO")
+
+
+def test_get_recursive_with_list():
+    cfg = get_cfg()
+    cfg.DESCRIPTION.BRIEF = "foobar"
+
+    assert cfg.get_recursive("DESCRIPTION.BRIEF[0]") == "f"
+    with pytest.raises(IndexError):
+        cfg.get_recursive("DESCRIPTION.BRIEF[1000]")

--- a/tests/config/test_config.py
+++ b/tests/config/test_config.py
@@ -55,10 +55,47 @@ def test_get_recursive():
         cfg.get_recursive("DESCRIPTION.FOO")
 
 
-def test_get_recursive_with_list():
+def test_get_recursive_with_index():
     cfg = get_cfg()
-    cfg.DESCRIPTION.BRIEF = "foobar"
 
+    cfg.DESCRIPTION.BRIEF = "foobar"
     assert cfg.get_recursive("DESCRIPTION.BRIEF[0]") == "f"
     with pytest.raises(IndexError):
         cfg.get_recursive("DESCRIPTION.BRIEF[1000]")
+
+    cfg.DESCRIPTION.TAGS = ["foobar", "baz"]
+    assert cfg.get_recursive("DESCRIPTION.TAGS[0]") == "foobar"
+    assert cfg.get_recursive("DESCRIPTION.TAGS[1]") == "baz"
+    assert cfg.get_recursive("DESCRIPTION.TAGS[-1]") == "baz"
+    with pytest.raises(IndexError):
+        cfg.get_recursive("DESCRIPTION.TAGS[1000]")
+
+
+def test_set_recursive():
+    cfg = get_cfg()
+    cfg.set_recursive("DESCRIPTION.BRIEF", "foobar")
+    assert cfg.DESCRIPTION.BRIEF == "foobar"
+
+
+def test_set_recursive_with_index():
+    cfg = get_cfg()
+    cfg.DESCRIPTION.TAGS = ("foobar", "baz")
+    cfg.set_recursive("DESCRIPTION.TAGS[0]", "hello")
+    assert cfg.DESCRIPTION.TAGS == ("hello", "baz")
+
+    # Multi-nested list.
+    # cfg = get_cfg()
+    # cfg.DESCRIPTION.TAGS = [("foobar", "baz"), "goodbye"]
+    # cfg.set_recursive("DESCRIPTION.TAGS[0][0]", "hello")
+    # assert cfg.DESCRIPTION.TAGS == [("hello", "baz"), "goodbye"]
+
+    # Nested list replace with different type.
+    cfg = get_cfg()
+    cfg.DESCRIPTION.TAGS = [("foobar", "baz"), "goodbye"]
+    cfg.set_recursive("DESCRIPTION.TAGS[0]", "hello")
+    assert cfg.DESCRIPTION.TAGS == ["hello", "goodbye"]
+
+    # Cannot replace values in a string.
+    cfg = get_cfg()
+    with pytest.raises(TypeError):
+        cfg.set_recursive("DESCRIPTION.BRIEF[0]", "hello")

--- a/tests/config/test_config.py
+++ b/tests/config/test_config.py
@@ -57,18 +57,23 @@ def test_get_recursive():
 
 def test_get_recursive_with_index():
     cfg = get_cfg()
-
+    # Index into string.
     cfg.DESCRIPTION.BRIEF = "foobar"
     assert cfg.get_recursive("DESCRIPTION.BRIEF[0]") == "f"
     with pytest.raises(IndexError):
         cfg.get_recursive("DESCRIPTION.BRIEF[1000]")
 
+    # Index into list/tuple.
     cfg.DESCRIPTION.TAGS = ["foobar", "baz"]
     assert cfg.get_recursive("DESCRIPTION.TAGS[0]") == "foobar"
     assert cfg.get_recursive("DESCRIPTION.TAGS[1]") == "baz"
     assert cfg.get_recursive("DESCRIPTION.TAGS[-1]") == "baz"
     with pytest.raises(IndexError):
         cfg.get_recursive("DESCRIPTION.TAGS[1000]")
+
+    # Multi-nested index.
+    # cfg.DESCRIPTION.TAGS = [("foobar", "baz"), "goodbye"]
+    # assert cfg.get_recursive("DESCRIPTION.TAGS[0][0]") == "foobar"
 
 
 def test_set_recursive():
@@ -83,12 +88,6 @@ def test_set_recursive_with_index():
     cfg.set_recursive("DESCRIPTION.TAGS[0]", "hello")
     assert cfg.DESCRIPTION.TAGS == ("hello", "baz")
 
-    # Multi-nested list.
-    # cfg = get_cfg()
-    # cfg.DESCRIPTION.TAGS = [("foobar", "baz"), "goodbye"]
-    # cfg.set_recursive("DESCRIPTION.TAGS[0][0]", "hello")
-    # assert cfg.DESCRIPTION.TAGS == [("hello", "baz"), "goodbye"]
-
     # Nested list replace with different type.
     cfg = get_cfg()
     cfg.DESCRIPTION.TAGS = [("foobar", "baz"), "goodbye"]
@@ -99,3 +98,9 @@ def test_set_recursive_with_index():
     cfg = get_cfg()
     with pytest.raises(TypeError):
         cfg.set_recursive("DESCRIPTION.BRIEF[0]", "hello")
+
+    # Multi-nested list.
+    # cfg = get_cfg()
+    # cfg.DESCRIPTION.TAGS = [("foobar", "baz"), "goodbye"]
+    # cfg.set_recursive("DESCRIPTION.TAGS[0][0]", "hello")
+    # assert cfg.DESCRIPTION.TAGS == [("hello", "baz"), "goodbye"]

--- a/tests/config/test_config.py
+++ b/tests/config/test_config.py
@@ -10,7 +10,7 @@ def test_format_fields():
     assert cfg.DESCRIPTION.BRIEF == f"seed={cfg.SEED},project={cfg.DESCRIPTION.PROJECT_NAME}"
 
     cfg = get_cfg()
-    cfg.DESCRIPTION.BRIEF = 'f"{SEED},project={DESCRIPTION.PROJECT_NAME}"'
+    cfg.DESCRIPTION.BRIEF = "f'{SEED},project={DESCRIPTION.PROJECT_NAME}'"
     cfg.format_fields()
     assert cfg.DESCRIPTION.BRIEF == f"{cfg.SEED},project={cfg.DESCRIPTION.PROJECT_NAME}"
 
@@ -19,6 +19,8 @@ def test_format_fields():
     cfg.format_fields()
     assert cfg.DESCRIPTION.BRIEF == f"{cfg.SEED},project={cfg.DESCRIPTION.PROJECT_NAME}-today"
 
+
+def test_format_fields_unroll():
     cfg = get_cfg()
     cfg.AUG_TRAIN.UNDERSAMPLE.ACCELERATIONS = (6, 8)
     cfg.DESCRIPTION.BRIEF = (


### PR DESCRIPTION
Format strings that are nested in lists

```
# load SOLVER.MAX_ITER as a tag
cfg.DESCRIPTION.TAGS = ["tag1", f"{cfg.SOLVER.MAX_ITER}"]
```

Changes:
- `set_recursive` can be called with list indexing
  - e.g. `cfg.set_recursive("cfg.DESCRIPTION.TAGS[0]", "new_tag")`

What doesnt work:
- We can't updated nested values in dictionaries
  - e.g. `set_recursive("cfg.DESCRIPTION.TAGS[0][0]", "new_value")`